### PR TITLE
Fixes for the API method

### DIFF
--- a/LBRY.class.php
+++ b/LBRY.class.php
@@ -20,12 +20,12 @@ class LBRY
     {
       $responseData = json_decode($serverOutput, true);
 
-      if (isset($responseData['result'])) {
-        return $responseData['result'];
+      if (isset($responseData['error'])) {
+        throw new Exception($responseData['error']);
       }
 
-      if (isset($responseData[0])) {
-        return $responseData[0];
+      if (isset($responseData['result'])) {
+        return $responseData['result'];
       }
     }
   }
@@ -44,6 +44,7 @@ class LBRY
       return
         //TODO: Expand these checks
         ($metadata['license'] == "Public Domain" || stripos($metadata['license'], 'Creative Commons') !== false) &&
+        in_array($metadata['content_type'], ['image/jpeg', 'image/png']) &&
         !isset($metadata['fee']);
     });
 

--- a/LBRY.class.php
+++ b/LBRY.class.php
@@ -13,22 +13,27 @@ class LBRY
     curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode(['method' => $function, 'params' => $params]));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-    $server_output = curl_exec($ch);
+    $serverOutput = curl_exec($ch);
+    curl_close($ch);
 
-    if ($server_output)
+    if ($serverOutput)
     {
-      $responseData = json_decode($server_output, true);
-      return $responseData['result'];
+      $responseData = json_decode($serverOutput, true);
+
+      if (isset($responseData['result'])) {
+        return $responseData['result'];
+      }
+
+      if (isset($responseData[0])) {
+        return $responseData[0];
+      }
     }
-
-    curl_close ($ch);
-
-    return $server_output;
   }
 
   public static function findTopPublicFreeClaim($name)
   {
     $claims = LBRY::api('claim_list', ['name' => $name]);
+
     if (!$claims || !isset($claims['claims']))
     {
       return null;


### PR DESCRIPTION
When attempting to get the API results they were returned in `$responseData[0]` instead of the expected `$responseData['results']`. I'm not sure why that would be, I'm running the latest (non-rc) release.

I also make sure to close the curl connection before leaving the method.