### PR TITLE
Dealing with lack of claims as a success

### DIFF
--- a/controllers/serveController.js
+++ b/controllers/serveController.js
@@ -111,6 +111,11 @@ module.exports = {
       // 1. get the top free, public claims
       getAllFreePublicClaims(claimName)
         .then(freePublicClaimList => {
+          // check to make sure some claims were found
+          if (!freePublicClaimList) {
+            resolve(null);
+            return;
+          }
           const name = freePublicClaimList[0].name;
           const claimId = freePublicClaimList[0].claim_id;
           const uri = `${name}#${claimId}`;
@@ -119,7 +124,7 @@ module.exports = {
           db.File
             .findOne({ where: { name, claimId } })
             .then(claim => {
-              // 3. if a matching claim_id is found locally, serve it
+              // 3. if a matching record is found locally, serve it
               if (claim) {
                 // serve the file
                 resolve(claim.dataValues);
@@ -164,7 +169,7 @@ module.exports = {
                 // check to make sure the result is a claim
                 if (!result.claim) {
                   logger.debug('resolve did not return a claim');
-                  reject('NO_FREE_PUBLIC_CLAIMS');  // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
+                  resolve(null);
                   return;
                 }
                 // 4. check to see if the claim is free & public
@@ -172,7 +177,7 @@ module.exports = {
                   // 5. get claim and serve
                   getClaimAndHandleResponse(uri, result.claim.height, resolve, reject);
                 } else {
-                  reject('NO_FREE_PUBLIC_CLAIMS');  // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
+                  reject(null);
                 }
               })
               .catch(error => {

--- a/controllers/statsController.js
+++ b/controllers/statsController.js
@@ -6,7 +6,7 @@ const googleApiKey = config.get('AnalyticsConfig.GoogleId');
 
 module.exports = {
   postToStats: (action, url, ipAddress, result) => {
-    logger.silly('creating record for statistics db');
+    logger.silly(`creating ${action} record for statistics db`);
     // make sure the result is a string
     if (result && (typeof result !== 'string')) {
       result = result.toString();

--- a/helpers/functions/getAllFreePublicClaims.js
+++ b/helpers/functions/getAllFreePublicClaims.js
@@ -34,20 +34,19 @@ module.exports = claimName => {
     lbryApi
       .getClaimsList(claimName)
       .then(({ claims }) => {
-        const claimsList = claims;
-        logger.debug(`Number of claims: ${claimsList.length}`);
+        logger.debug(`Number of claims: ${claims.length}`);
         // return early if no claims were found
-        if (claimsList.length === 0) {
-          reject('NO_CLAIMS'); // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
+        if (claims.length === 0) {
           logger.debug('exiting due to lack of claims');
+          resolve(null);
           return;
         }
         // filter the claims to return only free, public claims
-        const freePublicClaims = filterForFreePublicClaims(claimsList);
+        const freePublicClaims = filterForFreePublicClaims(claims);
         // return early if no free, public claims were found
         if (!freePublicClaims || freePublicClaims.length === 0) {
-          reject('NO_FREE_PUBLIC_CLAIMS'); // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
           logger.debug('exiting due to lack of free or public claims');
+          resolve(null);
           return;
         }
         // order the claims

--- a/helpers/functions/getAllFreePublicClaims.js
+++ b/helpers/functions/getAllFreePublicClaims.js
@@ -38,7 +38,7 @@ module.exports = claimName => {
         logger.debug(`Number of claims: ${claimsList.length}`);
         // return early if no claims were found
         if (claimsList.length === 0) {
-          reject('NO_CLAIMS');
+          reject('NO_CLAIMS'); // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
           logger.debug('exiting due to lack of claims');
           return;
         }
@@ -46,7 +46,7 @@ module.exports = claimName => {
         const freePublicClaims = filterForFreePublicClaims(claimsList);
         // return early if no free, public claims were found
         if (!freePublicClaims || freePublicClaims.length === 0) {
-          reject('NO_FREE_PUBLIC_CLAIMS');
+          reject('NO_FREE_PUBLIC_CLAIMS'); // note: should be a resolve not a reject! but I need routes to handle that properly. right now it is handled as an error.
           logger.debug('exiting due to lack of free or public claims');
           return;
         }

--- a/helpers/libraries/errorHandlers.js
+++ b/helpers/libraries/errorHandlers.js
@@ -4,10 +4,7 @@ const { postToStats } = require('../../controllers/statsController.js');
 module.exports = {
   handleRequestError (action, originalUrl, ip, error, res) {
     logger.error('Request Error >>', error);
-    if (error === 'NO_CLAIMS' || error === 'NO_FREE_PUBLIC_CLAIMS') {
-      postToStats(action, originalUrl, ip, 'success');
-      res.status(307).render('noClaims');
-    } else if (error.response) {
+    if (error.response) {
       postToStats(action, originalUrl, ip, error.response.data.error.messsage);
       res.status(error.response.status).send(error.response.data.error.message);
     } else if (error.code === 'ECONNREFUSED') {

--- a/helpers/libraries/lbryApi.js
+++ b/helpers/libraries/lbryApi.js
@@ -78,7 +78,7 @@ module.exports = {
             reject(data.result[uri].error);
             return;
           }
-          resolve(data.result);
+          resolve(data.result[uri]);
         })
         .catch(error => {
           reject(error);

--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -47,6 +47,11 @@ module.exports = (app) => {
     serveController
       .getClaimByClaimId(params.name, params.claim_id)
       .then(fileInfo => {
+        // check to make sure a file was found
+        if (!fileInfo) {
+          res.status(307).render('noClaims');
+          return;
+        }
         postToStats('serve', originalUrl, ip, 'success');
         serveFile(fileInfo, res);
       })
@@ -61,6 +66,11 @@ module.exports = (app) => {
     serveController
       .getClaimByName(params.name)
       .then(fileInfo => {
+        // check to make sure a file was found
+        if (!fileInfo) {
+          res.status(307).render('noClaims');
+          return;
+        }
         postToStats('serve', originalUrl, ip, 'success');
         serveFile(fileInfo, res);
       })

--- a/routes/show-routes.js
+++ b/routes/show-routes.js
@@ -44,6 +44,10 @@ module.exports = (app) => {
     // get and render the content
     getAllClaims(params.name)
       .then(orderedFreePublicClaims => {
+        if (!orderedFreePublicClaims) {
+          res.status(307).render('noClaims');
+          return;
+        }
         postToStats('show', originalUrl, ip, 'success');
         res.status(200).render('allClaims', { claims: orderedFreePublicClaims });
       })


### PR DESCRIPTION
This PR is to fix the issue described here:  https://github.com/lbryio/spee.ch/issues/61

Previously a lack of free, public claims was treated as an error.  However, the daemon was not actually returning an error or failing in any way.  Therefore, a lack of free, public claims will now be treated as a successful request that bore no results.