### PR TITLE
Block used claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-ApiPublishTest.html

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ spee.ch is a single-serving site that reads and publishes images to and from the
 	* a successfull request returns the resolve results for the claim at that name in JSON format
 * /api/claim_list/:name
 	* a successfull request returns a list of claims at that claim name in JSON format
+* /api/isClaimAvailable/:name
+	* a successfull request returns a boolean: `true` if the name is still available, `false` if the name has already been published to by spee.ch.
 
 #### POST
 * /api/publish

--- a/controllers/publishController.js
+++ b/controllers/publishController.js
@@ -63,4 +63,18 @@ module.exports = {
     });
     return deferred;
   },
+  checkNameAvailability: (name) => {
+    const deferred = new Promise((resolve, reject) => {
+      // find any records where the name is used
+      db.File
+        .findAll({ where: { name } })
+        .then(result => {
+          resolve(result);
+        })
+        .catch(error => {
+          reject(error);
+        });
+    });
+    return deferred;
+  },
 };

--- a/controllers/publishController.js
+++ b/controllers/publishController.js
@@ -20,19 +20,20 @@ function upsert (Model, values, condition) {
 }
 
 module.exports = {
-  publish: (publishParams, fileName, fileType) => {
+  publish (publishParams, fileName, fileType) {
     const deferred = new Promise((resolve, reject) => {
       // 1. publish the file
       lbryApi
         .publishClaim(publishParams)
         .then(result => {
           logger.info(`Successfully published ${fileName}`, result);
-          // 2. update old record of create new one (update is in case the claim has been published before by this daemon)
+          // 2. update old record or create new one (update is in case the claim has been published before by this daemon)
           upsert(
             db.File,
             {
               name    : publishParams.name,
               claimId : result.claim_id,
+              address : publishParams.claim_address,
               outpoint: `${result.txid}:${result.nout}`,
               height  : 0,
               fileName,
@@ -63,13 +64,32 @@ module.exports = {
     });
     return deferred;
   },
-  checkNameAvailability: (name) => {
+  checkNameAvailability (name) {
     const deferred = new Promise((resolve, reject) => {
       // find any records where the name is used
       db.File
         .findAll({ where: { name } })
         .then(result => {
-          resolve(result);
+          if (result.length >= 1) {
+            // filter out any results that were not published from a spee.ch wallet address
+            lbryApi
+              .getWalletList()
+              .then((walletList) => {
+                const filteredResult = result.filter((claim) => {
+                  return walletList.includes(claim.address);
+                });
+                if (filteredResult.length >= 1) {
+                  resolve(false);
+                } else {
+                  resolve(true);
+                }
+              })
+              .catch((error) => {
+                reject(error);
+              });
+          } else {
+            resolve(true);
+          }
         })
         .catch(error => {
           reject(error);

--- a/controllers/publishController.js
+++ b/controllers/publishController.js
@@ -19,82 +19,98 @@ function upsert (Model, values, condition) {
     });
 }
 
+function checkNameAvailability (name) {
+  const deferred = new Promise((resolve, reject) => {
+    // find any records where the name is used
+    db.File
+      .findAll({ where: { name } })
+      .then(result => {
+        if (result.length >= 1) {
+          // filter out any results that were not published from a spee.ch wallet address
+          lbryApi
+            .getWalletList()
+            .then((walletList) => {
+              const filteredResult = result.filter((claim) => {
+                return walletList.includes(claim.address);
+              });
+              if (filteredResult.length >= 1) {
+                resolve(false);
+              } else {
+                resolve(true);
+              }
+            })
+            .catch((error) => {
+              reject(error);
+            });
+        } else {
+          resolve(true);
+        }
+      })
+      .catch(error => {
+        reject(error);
+      });
+  });
+  return deferred;
+};
+
 module.exports = {
   publish (publishParams, fileName, fileType) {
     const deferred = new Promise((resolve, reject) => {
-      // 1. publish the file
-      lbryApi
-        .publishClaim(publishParams)
-        .then(result => {
-          logger.info(`Successfully published ${fileName}`, result);
-          // 2. update old record or create new one (update is in case the claim has been published before by this daemon)
-          upsert(
-            db.File,
-            {
-              name    : publishParams.name,
-              claimId : result.claim_id,
-              address : publishParams.claim_address,
-              outpoint: `${result.txid}:${result.nout}`,
-              height  : 0,
-              fileName,
-              filePath: publishParams.file_path,
-              fileType,
-              nsfw    : publishParams.metadata.nsfw,
-            },
-            {
-              name   : publishParams.name,
-              claimId: result.claim_id,
-            }
-          ).then(() => {
-            // resolve the promise with the result from lbryApi.publishClaim;
-            resolve(result);
-          })
-          .catch(error => {
-            logger.error('Sequelize findOne error', error);
-            // reject the promise
-            reject(error);
-          });
-        })
-        .catch(error => {
-          // delete the local file
-          publishHelpers.deleteTemporaryFile(publishParams.file_path);
-          // reject the promise
-          reject(error);
-        });
+      // 1. make sure the name is available
+      checkNameAvailability(publishParams.name)
+      .then(result => {
+        if (result === true) {
+          // 2. publish the file
+          lbryApi
+            .publishClaim(publishParams)
+            .then(result => {
+              logger.info(`Successfully published ${fileName}`, result);
+              // 3. update old record or create new one (update is in case the claim has been published before by this daemon)
+              upsert(
+                db.File,
+                {
+                  name    : publishParams.name,
+                  claimId : result.claim_id,
+                  address : publishParams.claim_address,
+                  outpoint: `${result.txid}:${result.nout}`,
+                  height  : 0,
+                  fileName,
+                  filePath: publishParams.file_path,
+                  fileType,
+                  nsfw    : publishParams.metadata.nsfw,
+                },
+                {
+                  name   : publishParams.name,
+                  claimId: result.claim_id,
+                }
+              ).then(() => {
+                // resolve the promise with the result from lbryApi.publishClaim;
+                resolve(result);
+              })
+              .catch(error => {
+                logger.error('Sequelize findOne error', error);
+                // reject the promise
+                reject(error);
+              });
+            })
+            .catch(error => {
+              // delete the local file
+              publishHelpers.deleteTemporaryFile(publishParams.file_path);
+              // reject the promise
+              reject(error);
+            });
+        } else {
+          const err = new Error('That name has already been claimed by spee.ch.  Please choose a new claim name.');
+          reject(err);
+        }
+      })
+      .catch(error => {
+        reject(error);
+      });
     });
     return deferred;
   },
   checkNameAvailability (name) {
-    const deferred = new Promise((resolve, reject) => {
-      // find any records where the name is used
-      db.File
-        .findAll({ where: { name } })
-        .then(result => {
-          if (result.length >= 1) {
-            // filter out any results that were not published from a spee.ch wallet address
-            lbryApi
-              .getWalletList()
-              .then((walletList) => {
-                const filteredResult = result.filter((claim) => {
-                  return walletList.includes(claim.address);
-                });
-                if (filteredResult.length >= 1) {
-                  resolve(false);
-                } else {
-                  resolve(true);
-                }
-              })
-              .catch((error) => {
-                reject(error);
-              });
-          } else {
-            resolve(true);
-          }
-        })
-        .catch(error => {
-          reject(error);
-        });
-    });
-    return deferred;
+    return checkNameAvailability(name);
   },
 };

--- a/controllers/statsController.js
+++ b/controllers/statsController.js
@@ -5,7 +5,7 @@ const db = require('../models');
 const googleApiKey = config.get('AnalyticsConfig.GoogleId');
 
 module.exports = {
-  postToStats: (action, url, ipAddress, result) => {
+  postToStats (action, url, ipAddress, result) {
     logger.silly(`creating ${action} record for statistics db`);
     // make sure the result is a string
     if (result && (typeof result !== 'string')) {
@@ -27,7 +27,7 @@ module.exports = {
       logger.error('sequelize error', error);
     });
   },
-  sendGoogleAnalytics: (action, ip, originalUrl) => {
+  sendGoogleAnalytics (action, ip, originalUrl) {
     const visitorId = ip.replace(/\./g, '-');
     const visitor = ua(googleApiKey, visitorId, { strictCidFormat: false, https: true });
     switch (action) {
@@ -55,7 +55,7 @@ module.exports = {
       default: break;
     }
   },
-  getStatsSummary: () => {
+  getStatsSummary () {
     logger.debug('retrieving site statistics');
     const deferred = new Promise((resolve, reject) => {
       // get the raw statistics data

--- a/helpers/functions/getAllFreePublicClaims.js
+++ b/helpers/functions/getAllFreePublicClaims.js
@@ -28,7 +28,7 @@ function orderClaims (claimsListArray) {
   return claimsListArray;
 }
 
-module.exports = claimName => {
+module.exports = (claimName) => {
   const deferred = new Promise((resolve, reject) => {
     // make a call to the daemon to get the claims list
     lbryApi

--- a/helpers/libraries/errorHandlers.js
+++ b/helpers/libraries/errorHandlers.js
@@ -3,7 +3,7 @@ const { postToStats } = require('../../controllers/statsController.js');
 
 module.exports = {
   handleRequestError (action, originalUrl, ip, error, res) {
-    logger.error('Request Error >>', error);
+    logger.error('Request Error >>', error.message);
     if (error.response) {
       postToStats(action, originalUrl, ip, error.response.data.error.messsage);
       res.status(error.response.status).send(error.response.data.error.message);
@@ -12,7 +12,7 @@ module.exports = {
       res.status(503).send('Connection refused.  The daemon may not be running.');
     } else {
       postToStats(action, originalUrl, ip, error);
-      res.status(400).send(JSON.stringify(error));
+      res.status(400).send(error.message);
     }
   },
   handlePublishError (error) {

--- a/helpers/libraries/errorHandlers.js
+++ b/helpers/libraries/errorHandlers.js
@@ -23,7 +23,7 @@ module.exports = {
       logger.error('Publish Error:', error.response.data.error);
       return error.response.data.error.message;
     } else {
-      logger.error('Unhandled Publish Error:', error);
+      logger.error('Unhandled Publish Error:', error.message);
       return error;
     }
   },

--- a/helpers/libraries/lbryApi.js
+++ b/helpers/libraries/lbryApi.js
@@ -2,6 +2,23 @@ const axios = require('axios');
 const logger = require('winston');
 
 module.exports = {
+  getWalletList () {
+    logger.debug('getting wallet list');
+    const deferred = new Promise((resolve, reject) => {
+      axios
+        .post('http://localhost:5279/lbryapi', {
+          method: 'wallet_list',
+        })
+        .then(response => {
+          const result = response.data.result;
+          resolve(result);
+        })
+        .catch(error => {
+          reject(error);
+        });
+    });
+    return deferred;
+  },
   publishClaim (publishParams) {
     logger.debug(`Publishing claim to "${publishParams.name}"`);
     const deferred = new Promise((resolve, reject) => {

--- a/helpers/libraries/publishHelpers.js
+++ b/helpers/libraries/publishHelpers.js
@@ -3,7 +3,7 @@ const config = require('config');
 const fs = require('fs');
 
 module.exports = {
-  createPublishParams: (name, filePath, license, nsfw) => {
+  createPublishParams (name, filePath, license, nsfw) {
     logger.debug(`Creating Publish Parameters for "${name}"`);
     // const payAddress = config.get('WalletConfig.LbryPayAddress');
     const claimAddress = config.get('WalletConfig.LbryClaimAddress');
@@ -40,7 +40,7 @@ module.exports = {
     logger.debug('publishParams:', publishParams);
     return publishParams;
   },
-  deleteTemporaryFile: (filePath) => {
+  deleteTemporaryFile (filePath) {
     fs.unlink(filePath, err => {
       if (err) throw err;
       logger.debug(`successfully deleted ${filePath}`);

--- a/models/file.js
+++ b/models/file.js
@@ -10,6 +10,10 @@ module.exports = (sequelize, { STRING, BOOLEAN, INTEGER }) => {
         type     : STRING,
         allowNull: false,
       },
+      address: {
+        type     : STRING,
+        allowNull: false,
+      },
       outpoint: {
         type     : STRING,
         allowNull: false,

--- a/public/assets/css/allStyle.css
+++ b/public/assets/css/allStyle.css
@@ -43,6 +43,7 @@ footer {
 .panel {
 	overflow: auto;
 	word-wrap: break-word;
+	margin-bottom: 1em;
 }
 
 .col-left, .col-right {

--- a/public/assets/css/allStyle.css
+++ b/public/assets/css/allStyle.css
@@ -9,6 +9,7 @@
 	margin-bottom: 2px;
 	padding-bottom: 2px;
 	border-bottom: 1px lightgrey solid;
+	margin-top: 2em;
 }
 
 .main {

--- a/public/assets/js/claimPublish.js
+++ b/public/assets/js/claimPublish.js
@@ -123,7 +123,6 @@ document.getElementById('publish-submit').addEventListener('click', function(eve
 				} else {
 					alert("That name has already been claimed by spee.ch.  Please choose a different name.");
 				}
-				
 			} else {
 				console.log("request to check claim name failed with status:", this.status);
 			};

--- a/public/assets/js/claimPublish.js
+++ b/public/assets/js/claimPublish.js
@@ -119,8 +119,7 @@ document.getElementById('publish-submit').addEventListener('click', function(eve
 		if (this.readyState == 4 ) {
 			if ( this.status == 200) {
 				if (this.response == true) {
-					console.log(true);
-					//uploader.submitFiles(stagedFiles);
+					uploader.submitFiles(stagedFiles);
 				} else {
 					alert("That name has already been claimed by spee.ch.  Please choose a different name.");
 				}

--- a/public/assets/js/claimPublish.js
+++ b/public/assets/js/claimPublish.js
@@ -118,8 +118,13 @@ document.getElementById('publish-submit').addEventListener('click', function(eve
 	xhttp.onreadystatechange = function() {
 		if (this.readyState == 4 ) {
 			if ( this.status == 200) {
-				console.log(this.response);
-				//uploader.submitFiles(stagedFiles);
+				if (this.response == true) {
+					console.log(true);
+					//uploader.submitFiles(stagedFiles);
+				} else {
+					alert("That name has already been claimed by spee.ch.  Please choose a different name.");
+				}
+				
 			} else {
 				console.log("request to check claim name failed with status:", this.status);
 			};

--- a/public/assets/js/claimPublish.js
+++ b/public/assets/js/claimPublish.js
@@ -83,7 +83,7 @@ document.getElementById('publish-submit').addEventListener('click', function(eve
 	event.preventDefault();
 	var name = document.getElementById('publish-name').value;
 	var invalidCharacters = /[^A-Za-z0-9,-]/.exec(name);
-	// validate 'name'
+	// validate 'name' field
 	if (invalidCharacters) {
 		alert(invalidCharacters + ' is not allowed. A-Z, a-z, 0-9, and "-" only.');
 		return;
@@ -91,28 +91,41 @@ document.getElementById('publish-submit').addEventListener('click', function(eve
 		alert("You must enter a name for your claim");
 		return;
 	}
-	// make sure a file was selected
-	if (stagedFiles) {
-		// make sure only 1 file was selected
-		if (stagedFiles.length > 1) {
-			alert("Only one file is allowed at a time");
-			return;
-		}
-		// make sure the content type is acceptable
-		switch (stagedFiles[0].type) {
-			case "image/png":
-			case "image/jpeg":
-			case "image/gif":
-			case "video/mp4":
-				uploader.submitFiles(stagedFiles);
-				break;
-			default:
-				alert("Only .png, .jpeg, .gif, and .mp4 files are currently supported");
-				break;
-		}
-	} else {
+	// make sure only 1 file was selected
+	if (!stagedFiles) {
 		alert("Please select a file");
+		return;
+	} else if (stagedFiles.length > 1) {
+		alert("Only one file is allowed at a time");
+		return;
 	}
+	// make sure the content type is acceptable
+	switch (stagedFiles[0].type) {
+		case "image/png":
+		case "image/jpeg":
+		case "image/gif":
+		case "video/mp4":
+			break;
+		default:
+			alert("Only .png, .jpeg, .gif, and .mp4 files are currently supported");
+			return;
+	}
+	// make sure the name is available
+	var xhttp;
+	xhttp = new XMLHttpRequest();
+	xhttp.open('GET', '/api/isClaimAvailable/' + name, true);
+	xhttp.responseType = 'json';
+	xhttp.onreadystatechange = function() {
+		if (this.readyState == 4 ) {
+			if ( this.status == 200) {
+				console.log(this.response);
+				//uploader.submitFiles(stagedFiles);
+			} else {
+				console.log("request to check claim name failed with status:", this.status);
+			};
+		}
+	};
+	xhttp.send();
 })
 
 /* socketio-file-upload listeners */

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -33,10 +33,11 @@ module.exports = app => {
     publishController
       .checkNameAvailability(params.name)
       .then(result => {
-        if (result.length >= 1) {
-          res.status(200).json(false);
-        } else {
+        if (result === true) {
           res.status(200).json(true);
+        } else {
+          logger.debug(`Rejecting publish request because ${params.name} has already been published via spee.ch`);
+          res.status(200).json(false);
         }
       })
       .catch(error => {


### PR DESCRIPTION
1. added a column to the mysql File table for 'address' to track which `address` is associated with each downloaded file
2. added an API route `/api/isClaimAvailable/:name`.  This route checks the mysql File table for matching `name`s, and if one is found it compares the address in the record with the spee.ch wallet's addresses to see if it was published via spee.ch.  The route returns a boolean.
3. before submitting a request to publish, the client checks the name availability via `/api/isClaimAvailable`.
4. added server side check on name availability before publish because (a) race condition during upload time and also because (b) publish requests coming from other sources (e.g. /api/publish) need to be checked as well.