### PR TITLE
Accept spaces in filename, convert them to dashes

### DIFF
--- a/helpers/libraries/publishHelpers.js
+++ b/helpers/libraries/publishHelpers.js
@@ -26,10 +26,12 @@ module.exports = {
     }
 
     // validate name
-    const invalidCharacters = /[^A-Za-z0-9,-]/.exec(name);
+    const invalidCharacters = /[^A-Za-z0-9,- ]/.exec(name);
     if (invalidCharacters) {
       throw new Error('The name you provided is not allowed.  Please use A-Z, a-z, 0-9, and "-" only.');
     }
+    name = str.replace(/\s+/g, '-'); //replace space with dash/hyphen
+    
     // validate license
     if ((license.indexOf('Public Domain') === -1) && (license.indexOf('Creative Commons') === -1)) {
       throw new Error('Only posts with a license of "Public Domain" or "Creative Commons" are eligible for publishing through spee.ch');


### PR DESCRIPTION
Accept space in filename from user, and replace the space to dash. Since a lot of users are used to typing out with spaces, better UX and less errors thrown out for invalid names.