### PR TITLE
Add license cc attribution non commercial 4.0 international

### DIFF
--- a/helpers/functions/isFreePublicClaim.js
+++ b/helpers/functions/isFreePublicClaim.js
@@ -1,9 +1,9 @@
 const logger = require('winston');
-
+const licenses = ['Creative Commons', 'Public Domain', 'CC Attribution-NonCommercial 4.0 International'];
 module.exports = ({ value }) => {
   logger.debug('checking isFreePublicClaim ?');
   if (
-    (value.stream.metadata.license.indexOf('Public Domain') !== -1 || value.stream.metadata.license.indexOf('Creative Commons') !== -1) &&
+    (Array.asList(licenses).contains(value.stream.metadata.license)) &&
     (!value.stream.metadata.fee || value.stream.metadata.fee.amount === 0)
   ) {
     return true;

--- a/helpers/libraries/publishHelpers.js
+++ b/helpers/libraries/publishHelpers.js
@@ -30,8 +30,8 @@ module.exports = {
       throw new Error('The claim name you provided is not allowed.  Only the following characters are allowed: A-Z, a-z, 0-9, and "-"');
     }
     // validate license
-    if ((license.indexOf('Public Domain') === -1) && (license.indexOf('Creative Commons') === -1)) {
-      throw new Error('Only posts with a license of "Public Domain" or "Creative Commons" are eligible for publishing through spee.ch');
+    if ((license.indexOf('Public Domain') === -1) && (license.indexOf('Creative Commons') === -1) && (license.indecOf('CC Attribution-NonCommercial 4.0 International') === -1)) {
+      throw new Error('Only posts with a "Public Domain" license,  or one of the Creative Commons licenses are eligible for publishing through spee.ch');
     }
     switch (nsfw) {
       case true:

--- a/views/partials/publish.handlebars
+++ b/views/partials/publish.handlebars
@@ -20,6 +20,7 @@
 			<p class="stop-float">
 			<label for="publish-license">License:</label>
 			<select type="text" id="publish-license" name="license" value="license">
+				<option value="CC Attribution-NonCommercial 4.0 International"><a href="http://creativecommons.org/licenses/by-nc/4.0/">CC Attribution-NonCommercial 4.0 International</a></option>
 				<option value="Public Domain">Public Domain</option>
 				<option value="Creative Commons">Creative Commons</option>
 			</select> 


### PR DESCRIPTION
Add an additional license; licenses are stored in an array so that future modifications are simpler.