### PR TITLE
Twitter card

### DIFF
--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -36,7 +36,7 @@ module.exports = (app) => {
           const mimetypes = headers['accept'].split(',');
           if (mimetypes.includes('text/html')) {
             postToStats('show', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
-            res.status(200).render('showLite', { fileInfo });
+            res.status(200).render('showLite', { layout: 'show', fileInfo });
           } else {
             postToStats('serve', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
             serveFile(fileInfo, res);
@@ -67,7 +67,7 @@ module.exports = (app) => {
           const mimetypes = headers['accept'].split(',');
           if (mimetypes.includes('text/html')) {
             postToStats('show', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
-            res.status(200).render('showLite', { fileInfo });
+            res.status(200).render('showLite', { layout: 'show', fileInfo });
           } else {
             postToStats('serve', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
             serveFile(fileInfo, res);

--- a/routes/show-routes.js
+++ b/routes/show-routes.js
@@ -79,7 +79,7 @@ module.exports = (app) => {
         }
         // serve the file or the show route
         postToStats('show', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
-        res.status(200).render('show', { fileInfo });
+        res.status(200).render('show', { layout: 'show', fileInfo });
       })
       .catch(error => {
         errorHandlers.handleRequestError('show', originalUrl, ip, error, res);
@@ -97,7 +97,7 @@ module.exports = (app) => {
         }
         // serve the show route
         postToStats('show', originalUrl, ip, fileInfo.name, fileInfo.claimId, 'success');
-        res.status(200).render('show', { fileInfo });
+        res.status(200).render('show', { layout: 'show', fileInfo });
       })
       .catch(error => {
         errorHandlers.handleRequestError('show', originalUrl, ip, error, res);

--- a/speech.js
+++ b/speech.js
@@ -72,16 +72,6 @@ const hbs = expressHandlebars.create({
           return options.inverse(this);
       }
     },
-    twitterCard (type) {
-      return new Handlebars.SafeString(`
-      <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:site" content="@spee.ch">
-      <meta name="twitter:creator" content="@SarahMaslinNir">
-      <meta name="twitter:title" content="Parade of Fans for Houston’s Funeral">
-      <meta name="twitter:description" content="NEWARK - The guest list and parade of limousines with celebrities emerging from them seemed more suited to a red carpet event in Hollywood or New York than than a gritty stretch of Sussex Avenue near the former site of the James M. Baxter Terrace public housing project here.">
-      <meta name="twitter:image" content="http://graphics8.nytimes.com/images/2012/02/19/us/19whitney-span/19whitney-span-articleLarge.jpg">
-      `);
-    },
   },
 });
 app.engine('handlebars', hbs.engine);

--- a/speech.js
+++ b/speech.js
@@ -72,21 +72,15 @@ const hbs = expressHandlebars.create({
           return options.inverse(this);
       }
     },
-    grouped_each (every, context, options) {
-      let out = '';
-      let subcontext = [];
-      let i;
-      if (context && context.length > 0) {
-        for (i = 0; i < context.length; i++) {
-          if (i > 0 && i % every === 0) {
-            out += options.fn(subcontext);
-            subcontext = [];
-          }
-          subcontext.push(context[i]);
-        }
-        out += options.fn(subcontext);
-      }
-      return out;
+    twitterCard (type) {
+      return new Handlebars.SafeString(`
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:site" content="@spee.ch">
+      <meta name="twitter:creator" content="@SarahMaslinNir">
+      <meta name="twitter:title" content="Parade of Fans for Houston’s Funeral">
+      <meta name="twitter:description" content="NEWARK - The guest list and parade of limousines with celebrities emerging from them seemed more suited to a red carpet event in Hollywood or New York than than a gritty stretch of Sussex Avenue near the former site of the James M. Baxter Terrace public housing project here.">
+      <meta name="twitter:image" content="http://graphics8.nytimes.com/images/2012/02/19/us/19whitney-span/19whitney-span-articleLarge.jpg">
+      `);
     },
   },
 });

--- a/views/layouts/show.handlebars
+++ b/views/layouts/show.handlebars
@@ -13,7 +13,7 @@
 	<meta name="twitter:creator" content="@spee.ch">
 	<meta name="twitter:title" content="{{fileInfo.name}}">
 	<meta name="twitter:description" content="An image hosted via Spee.ch">
-	<meta name="twitter:image" content="/api/streamFile/{{fileInfo.fileName}}">
+	<meta name="twitter:image" content="https://spee.ch/api/streamFile/{{fileInfo.fileName}}">
 </head>
 <body>
 	{{{ body }}}

--- a/views/layouts/show.handlebars
+++ b/views/layouts/show.handlebars
@@ -7,7 +7,13 @@
 	<title>Spee.ch</title>
 	<link rel="stylesheet" href="/assets/css/generalStyle.css" type="text/css">
 	<link rel="stylesheet" href="/assets/css/componentStyle.css" type="text/css">
-	{{ twitterCard }}
+	<!-- twitter card -->
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:site" content="@spee.ch">
+	<meta name="twitter:creator" content="@spee.ch">
+	<meta name="twitter:title" content="{{fileInfo.name}}">
+	<meta name="twitter:description" content="An image hosted via Spee.ch">
+	<meta name="twitter:image" content="/api/streamFile/{{fileInfo.fileName}}">
 </head>
 <body>
 	{{{ body }}}


### PR DESCRIPTION
- added twitter card support for 'show' actions for images.  
    - support for 'serve' actions will require a more invasive update in order to send html when twitter is trying to unfurl.
    - support for unfurling gifs and videos will require applying to be white listed via twitter for Player Cards