### PR TITLE
added basic support for showing .mp4 as .givf

### DIFF
--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -26,9 +26,13 @@ function getAsset (claimType, channelName, shortId, fullClaimId, name) {
   }
 }
 
-function serveOrShowAsset (fileInfo, method, headers, originalUrl, ip, res) {
+function serveOrShowAsset (fileInfo, extension, method, headers, originalUrl, ip, res) {
   // add file extension to the file info
-  fileInfo['fileExt'] = fileInfo.fileName.substring(fileInfo.fileName.lastIndexOf('.'));
+  if (extension === '.gifv') {
+    fileInfo['fileExt'] = '.gifv';
+  } else {
+    fileInfo['fileExt'] = fileInfo.fileName.substring(fileInfo.fileName.lastIndexOf('.'));
+  }
   // serve or show
   switch (method) {
     case SERVE:
@@ -106,7 +110,7 @@ module.exports = (app) => {
       name = identifier;
       identifier = tempName;
     }
-    /* end */
+    /* end patch */
     logger.debug('claim name =', name);
     logger.debug('method =', method);
     // parse identifier for whether it is a channel, short url, or claim_id
@@ -134,7 +138,7 @@ module.exports = (app) => {
       if (!fileInfo) {
         res.status(200).render('noClaims');
       } else {
-        return serveOrShowAsset(fileInfo, method, headers, originalUrl, ip, res);
+        return serveOrShowAsset(fileInfo, extension, method, headers, originalUrl, ip, res);
       }
     })
     // 3. update the file
@@ -174,7 +178,7 @@ module.exports = (app) => {
       if (!fileInfo) {
         res.status(200).render('noClaims');
       } else {
-        return serveOrShowAsset(fileInfo, method, headers, originalUrl, ip, res);
+        return serveOrShowAsset(fileInfo, null, method, headers, originalUrl, ip, res);
       }
     })
     // 3. update the database

--- a/views/partials/asset.handlebars
+++ b/views/partials/asset.handlebars
@@ -2,11 +2,19 @@
 	<div id="asset-placeholder">
 		<a href="/{{fileInfo.claimId}}/{{fileInfo.name}}{{fileInfo.fileExt}}">
 		{{#ifConditional fileInfo.fileType '===' 'video/mp4'}}
-			<video class="show-asset" autoplay loop controls>
-				<source src="/media/{{fileInfo.fileName}}">
-				{{!--fallback--}}
-				Your browser does not support the <code>video</code> element.
-			</video>
+			{{#ifConditional fileInfo.fileExt '===' '.gifv'}}
+				<video class="show-asset" autoplay loop muted>
+					<source src="/media/{{fileInfo.fileName}}">
+					{{!--fallback--}}
+					Your browser does not support the <code>video</code> element.
+				</video>
+			{{else}}
+				<video class="show-asset" autoplay controls>
+					<source src="/media/{{fileInfo.fileName}}">
+					{{!--fallback--}}
+					Your browser does not support the <code>video</code> element.
+				</video>
+			{{/ifConditional}}
 		{{else}}
 			<img  class="show-asset" src="/media/{{fileInfo.fileName}}" />
 		{{/ifConditional}}

--- a/views/partials/assetInfo.handlebars
+++ b/views/partials/assetInfo.handlebars
@@ -4,23 +4,30 @@
 </div>
 <div class="panel links">
 	<h2 class="subheader">Links</h2>
+	{{!--short direct link to asset--}}
+	<div class="share-option">
+		<a href="/{{fileInfo.shortId}}/{{fileInfo.name}}{{fileInfo.fileExt}}">Permanent Short Link</a> (most convenient)
+		<div class="input-error" id="input-error-copy-short-link" hidden="true"></div>
+		<br/>
+		<input type="text" id="short-link" class="link" readonly spellcheck="false" value="https://spee.ch/{{fileInfo.shortId}}/{{fileInfo.name}}{{fileInfo.fileExt}}" onclick="select()"/>
+		<button class="copy-button" data-elementtocopy="short-link" onclick="copyToClipboard(event)">copy</button>
+	</div>
 	{{!-- link to show route for asset--}}
 	<div class="share-option">
-		<a href="/{{fileInfo.claimId}}/{{fileInfo.name}}{{fileInfo.fileExt}}">Permanent Long Link</a>
-		(fastest service)
+		<a href="/{{fileInfo.claimId}}/{{fileInfo.name}}{{fileInfo.fileExt}}">Permanent Long Link</a> (fastest service)
 		<div class="input-error" id="input-error-copy-long-link" hidden="true"></div>
 		</br>
 		<input type="text" id="long-link" class="link" readonly onclick="select()" spellcheck="false" value="https://spee.ch/{{fileInfo.claimId}}/{{fileInfo.name}}{{fileInfo.fileExt}}"/>
 		<button class="copy-button" data-elementtocopy="long-link" onclick="copyToClipboard(event)">copy</button>
 	</div>
-	{{!--short direct link to asset--}}
+	{{!-- gif v link --}}
+	{{#ifConditional fileInfo.fileType '===' 'video/mp4'}}
 	<div class="share-option">
-		<a href="/{{fileInfo.shortId}}/{{fileInfo.name}}{{fileInfo.fileExt}}">Permanent Short Link</a>
-		(most convenient)
-		<div class="input-error" id="input-error-copy-short-link" hidden="true"></div>
+		<a href="/{{fileInfo.shortId}}/{{fileInfo.name}}.gifv">gifv</a>
+		<div class="input-error" id="input-error-copy-gifv-text" hidden="true"></div>
 		<br/>
-		<input type="text" id="short-link" class="link" readonly spellcheck="false" value="https://spee.ch/{{fileInfo.shortId}}/{{fileInfo.name}}{{fileInfo.fileExt}}" onclick="select()"/>
-		<button class="copy-button" data-elementtocopy="short-link" onclick="copyToClipboard(event)">copy</button>
+		<input type="text" id="gifv-text" class="link" readonly onclick="select()" spellcheck="false" value='https://spee.ch/{{fileInfo.shortId}}/{{fileInfo.name}}.gifv'/>
+		<button class="copy-button" data-elementtocopy="gifv-text" onclick="copyToClipboard(event)">copy</button>
 	</div>
 	{{!-- html text for embedding asset--}}
 	<div class="share-option">
@@ -34,6 +41,7 @@
 		{{/ifConditional}}
 		<button class="copy-button" data-elementtocopy="embed-text" onclick="copyToClipboard(event)">copy</button>
 	</div>
+	{{/ifConditional}}
 	{{!--markdown text using asset--}}
 	{{#ifConditional fileInfo.fileType '===' 'video/mp4'}}
 	{{else}}

--- a/views/showLite.handlebars
+++ b/views/showLite.handlebars
@@ -1,12 +1,19 @@
 <div id="asset-placeholder">
 	<a href="/{{fileInfo.claimId}}/{{fileInfo.name}}">
 	{{#ifConditional fileInfo.fileType '===' 'video/mp4'}}
-		<video class="show-asset-lite" autoplay loop controls>
-			<source src="/media/{{fileInfo.fileName}}">
-			{{!--fallback--}}
-			Your browser does not support the <code>video</code> element.
-		</video>
-
+		{{#ifConditional fileInfo.fileExt '===' '.gifv'}}
+			<video class="show-asset-light" autoplay loop muted>
+				<source src="/media/{{fileInfo.fileName}}">
+				{{!--fallback--}}
+				Your browser does not support the <code>video</code> element.
+			</video>
+		{{else}}
+			<video class="show-asset-light" autoplay controls>
+				<source src="/media/{{fileInfo.fileName}}">
+				{{!--fallback--}}
+				Your browser does not support the <code>video</code> element.
+			</video>
+		{{/ifConditional}}
 	{{else}}
 		<img class="show-asset-lite" src="/media/{{fileInfo.fileName}}" alt="{{fileInfo.fileName}}"/>
 	{{/ifConditional}}


### PR DESCRIPTION
- added basic support to show .mp4 as .givf if the .gifv extension is used on direct spee.ch urls (spee.ch/[claimId]/example.gifv and spee.ch/[shortId]/example.gifv).