### PR TITLE
Resolve channels

### DIFF
--- a/controllers/serveController.js
+++ b/controllers/serveController.js
@@ -1,7 +1,7 @@
 const lbryApi = require('../helpers/lbryApi.js');
 const db = require('../models');
 const logger = require('winston');
-const { getTopFreeClaim, getFullClaimIdFromShortId, resolveAgainstClaimTable } = require('../helpers/serveHelpers.js');
+const { getTopFreeClaim, getFullClaimIdFromShortId, resolveAgainstClaimTable, getClaimIdByChannelId } = require('../helpers/serveHelpers.js');
 
 function checkForLocalAssetByClaimId (claimId, name) {
   return new Promise((resolve, reject) => {
@@ -82,14 +82,21 @@ function getAssetByClaimId (fullClaimId, name) {
 }
 
 module.exports = {
-  getAssetByChannel (channelName, name) {
-    logger.debug('...getting asset by channel...');
-    return new Promise((resolve, reject) => {
-      // temporarily throw error
-      reject(new Error('channel names are not currently supported'));
-      // get the claim id
-      // get the asset by claim Id
-    });
+  getAssetByChannel (channelName, channelId, name) {
+    if (channelId) {
+      return new Promise((resolve, reject) => {
+        getClaimIdByChannelId(channelId, name)
+        .then(claimId => {
+          logger.debug('claim id = ', claimId);
+          resolve(getAssetByClaimId(claimId, name));
+        })
+        .catch(error => {
+          reject(error);
+        });
+      });
+    } else {
+      return new Error('this is not supported yet');
+    }
   },
   getAssetByShortId: function (shortId, name) {
     logger.debug('...getting asset by short id...');

--- a/controllers/serveController.js
+++ b/controllers/serveController.js
@@ -85,7 +85,7 @@ module.exports = {
   getAssetByChannel (channelName, channelId, claimName) {
     logger.debug('channelId =', channelId);
     return new Promise((resolve, reject) => {
-      getClaimIdByChannel(channelName, channelId)
+      getClaimIdByChannel(channelName, channelId, claimName)
       .then(claimId => {
         logger.debug('claim id = ', claimId);
         resolve(getAssetByClaimId(claimId, claimName));

--- a/controllers/serveController.js
+++ b/controllers/serveController.js
@@ -20,15 +20,24 @@ function checkForLocalAssetByClaimId (claimId, name) {
   });
 }
 
-function formatGetResultsToFileInfo ({ name, claim_id, outpoint, file_name, download_path, mime_type, metadata }) {
+function addGetResultsToFileRecord (fileInfo, getResult) {
+  fileInfo.fileName = getResult.file_name;
+  fileInfo.filePath = getResult.download_path;
+  fileInfo.fileType = getResult.mime_type;
+  return fileInfo;
+}
+
+function createFileRecord ({ name, claimId, outpoint, height, address, nsfw }) {
   return {
     name,
-    claimId : claim_id,
+    claimId,
     outpoint,
-    fileName: file_name,
-    filePath: download_path,
-    fileType: mime_type,
-    nsfw    : metadata.stream.metadata.nsfw,
+    height,
+    address,
+    fileName: '',
+    filePath: '',
+    fileType: '',
+    nsfw,
   };
 }
 
@@ -57,9 +66,8 @@ function getAssetByClaimId (fullClaimId, name) {
         lbryApi.getClaim(`${name}#${fullClaimId}`)
         .then(getResult => {
           logger.debug('getResult >>', getResult);
-          fileRecord = formatGetResultsToFileInfo(getResult);
-          fileRecord['address'] = (resolveResult.address || 0);
-          fileRecord['height'] = resolveResult.height;
+          fileRecord = createFileRecord(resolveResult);
+          fileRecord = addGetResultsToFileRecord(fileRecord, getResult);
           // insert a record in the File table & Update Claim table
           return db.File.create(fileRecord);
         })

--- a/controllers/serveController.js
+++ b/controllers/serveController.js
@@ -1,7 +1,7 @@
 const lbryApi = require('../helpers/lbryApi.js');
 const db = require('../models');
 const logger = require('winston');
-const { getTopFreeClaim, getFullClaimIdFromShortId, resolveAgainstClaimTable, getClaimIdByChannelId } = require('../helpers/serveHelpers.js');
+const { getTopFreeClaim, getFullClaimIdFromShortId, resolveAgainstClaimTable, getClaimIdByChannel } = require('../helpers/serveHelpers.js');
 
 function checkForLocalAssetByClaimId (claimId, name) {
   return new Promise((resolve, reject) => {
@@ -82,21 +82,18 @@ function getAssetByClaimId (fullClaimId, name) {
 }
 
 module.exports = {
-  getAssetByChannel (channelName, channelId, name) {
-    if (channelId) {
-      return new Promise((resolve, reject) => {
-        getClaimIdByChannelId(channelId, name)
-        .then(claimId => {
-          logger.debug('claim id = ', claimId);
-          resolve(getAssetByClaimId(claimId, name));
-        })
-        .catch(error => {
-          reject(error);
-        });
+  getAssetByChannel (channelName, channelId, claimName) {
+    logger.debug('channelId =', channelId);
+    return new Promise((resolve, reject) => {
+      getClaimIdByChannel(channelName, channelId)
+      .then(claimId => {
+        logger.debug('claim id = ', claimId);
+        resolve(getAssetByClaimId(claimId, claimName));
+      })
+      .catch(error => {
+        reject(error);
       });
-    } else {
-      return new Error('this is not supported yet');
-    }
+    });
   },
   getAssetByShortId: function (shortId, name) {
     logger.debug('...getting asset by short id...');
@@ -136,6 +133,12 @@ module.exports = {
       .catch(error => {
         reject(error);
       });
+    });
+  },
+  getChannelByName (name) {
+    logger.debug('...getting channel by channel name...');
+    return new Promise((resolve, reject) => {
+      reject(new Error('This feature is not yet supported'));
     });
   },
 };

--- a/controllers/statsController.js
+++ b/controllers/statsController.js
@@ -156,4 +156,18 @@ module.exports = {
       });
     });
   },
+  getRecentClaims (startDate) {
+    logger.debug('retrieving most recent claims');
+    return new Promise((resolve, reject) => {
+      // get the raw requests data
+      db.sequelize.query(`SELECT * FROM File WHERE nsfw != 1 AND trendingEligible = 1 ORDER BY createdAt DESC LIMIT 25;`, { type: db.sequelize.QueryTypes.SELECT })
+      .then(results => {
+        resolve(results);
+      })
+      .catch(error => {
+        logger.error('sequelize error', error);
+        reject(error);
+      });
+    });
+  },
 };

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,0 +1,8 @@
+module.exports = {
+  SERVE              : 'SERVE',
+  SHOW               : 'SHOW',
+  SHOWLITE           : 'SHOWLITE',
+  CHANNEL            : 'CHANNEL',
+  CLAIM              : 'CLAIM',
+  CHANNELID_INDICATOR: ':',
+};

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -224,7 +224,7 @@ module.exports = {
   getAllChannelClaims (channelId) {
     return new Promise((resolve, reject) => {
       logger.debug(`finding all claims in channel "${channelId}"`);
-      db.sequelize.query(`SELECT name, claimId, outpoint, height, address, contentType FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
+      db.sequelize.query(`SELECT name, claimId, outpoint, height, address, contentType, title, description, license FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
       .then(result => {
         switch (result.length) {
           case 0:

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -41,7 +41,7 @@ const db = require('../models');
 
 function getLongChannelId (channelName, channelId) {
   if (channelId && (channelId.length === 40)) {  // full channel id
-    return channelId;
+    return new Promise((resolve, reject) => resolve(channelId));
   } else if (channelId && channelId.length < 40) {  // short channel id
     return getLongChannelIdFromShortChannelId(channelName, channelId);
   } else {

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -49,10 +49,10 @@ function getLongChannelId (channelName, channelId) {
   }
 };
 
-function getClaimIdByLongChannelId (channelId, name) {
+function getClaimIdByLongChannelId (channelId, claimName) {
   return new Promise((resolve, reject) => {
-    logger.debug('finding claim id from channel id and claim name');
-    db.sequelize.query(`SELECT claimId FROM Claim WHERE name = '${name}' AND certificateId = '${channelId}' LIMIT 1;`, { type: db.sequelize.QueryTypes.SELECT })
+    logger.debug(`finding claim id for claim "${claimName}" from channel "${channelId}"`);
+    db.sequelize.query(`SELECT claimId FROM Claim WHERE name = '${claimName}' AND certificateId = '${channelId}' LIMIT 1;`, { type: db.sequelize.QueryTypes.SELECT })
     .then(result => {
       switch (result.length) {
         case 0:

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -172,7 +172,7 @@ function getShortChannelId (channelName, longChannelId) {
             });
           }
           // return the short Id
-          logger.debug('short claim id ===', shortId);
+          logger.debug('short channel id ===', shortId);
           return resolve(shortId);
       }
     })
@@ -334,12 +334,14 @@ module.exports = {
         return getAllChannelClaims(longChannelId);
       })
       .then(allChannelClaims => {
-        allChannelClaims.forEach(element => {
-          element['channelName'] = channelName;
-          element['longChannelId'] = longChannelId;
-          element['shortChannelId'] = shortChannelId;
-          element['fileExtension'] = element.contentType.substring(element.contentType.lastIndexOf('/') + 1);
-        });
+        if (allChannelClaims) {
+          allChannelClaims.forEach(element => {
+            element['channelName'] = channelName;
+            element['longChannelId'] = longChannelId;
+            element['shortChannelId'] = shortChannelId;
+            element['fileExtension'] = element.contentType.substring(element.contentType.lastIndexOf('/') + 1);
+          });
+        }
         return resolve(allChannelClaims);
       })
       .catch(error => {

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -127,6 +127,24 @@ module.exports = {
       });
     });
   },
+  getClaimIdByChannelId (channelId, name) {
+    return new Promise((resolve, reject) => {
+      logger.debug('finding claim id from channel id');
+      db.sequelize.query(`SELECT claimId FROM Claim WHERE name = '${name}' AND certificateId = '${channelId}' LIMIT 1;`, { type: db.sequelize.QueryTypes.SELECT })
+      .then(result => {
+        switch (result.length) {
+          case 0:
+            return reject(new Error('That is an invalid Channel Id'));
+          default: // note results must be sorted
+            logger.debug('found result', result);
+            return resolve(result[0].claimId);
+        }
+      })
+      .catch(error => {
+        reject(error);
+      });
+    });
+  },
   getAllFreeClaims (name) {
     return new Promise((resolve, reject) => {
       db.sequelize.query(`SELECT * FROM Claim WHERE name = '${name}' ORDER BY amount DESC, height ASC`, { type: db.sequelize.QueryTypes.SELECT })

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -172,7 +172,7 @@ module.exports = {
   },
   getAllFreeClaims (name) {
     return new Promise((resolve, reject) => {
-      db.sequelize.query(`SELECT * FROM Claim WHERE name = '${name}' ORDER BY amount DESC, height ASC`, { type: db.sequelize.QueryTypes.SELECT })
+      db.sequelize.query(`SELECT name, claimId, outpoint, height, address FROM Claim WHERE name = '${name}' ORDER BY amount DESC, height ASC`, { type: db.sequelize.QueryTypes.SELECT })
       .then(result => {
         switch (result.length) {
           case 0:
@@ -188,7 +188,7 @@ module.exports = {
   },
   resolveAgainstClaimTable (name, claimId) {
     return new Promise((resolve, reject) => {
-      db.sequelize.query(`SELECT * FROM Claim WHERE name = '${name}' AND claimId = '${claimId}'`, { type: db.sequelize.QueryTypes.SELECT })
+      db.sequelize.query(`SELECT name, claimId, outpoint, height, address, title, description FROM Claim WHERE name = '${name}' AND claimId = '${claimId}'`, { type: db.sequelize.QueryTypes.SELECT })
       .then(result => {
         switch (result.length) {
           case 0:
@@ -224,7 +224,7 @@ module.exports = {
   getAllChannelClaims (channelId) {
     return new Promise((resolve, reject) => {
       logger.debug(`finding all claims in channel "${channelId}"`);
-      db.sequelize.query(`SELECT * FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
+      db.sequelize.query(`SELECT name, claimId, outpoint, height, address FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
       .then(result => {
         switch (result.length) {
           case 0:

--- a/helpers/serveHelpers.js
+++ b/helpers/serveHelpers.js
@@ -224,7 +224,7 @@ module.exports = {
   getAllChannelClaims (channelId) {
     return new Promise((resolve, reject) => {
       logger.debug(`finding all claims in channel "${channelId}"`);
-      db.sequelize.query(`SELECT name, claimId, outpoint, height, address FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
+      db.sequelize.query(`SELECT name, claimId, outpoint, height, address, contentType FROM Claim WHERE certificateId = '${channelId}' ORDeR BY height DESC;`, { type: db.sequelize.QueryTypes.SELECT })
       .then(result => {
         switch (result.length) {
           case 0:

--- a/models/certificate.js
+++ b/models/certificate.js
@@ -1,0 +1,91 @@
+module.exports = (sequelize, { STRING, BOOLEAN, INTEGER, TEXT, ARRAY, DECIMAL, DOUBLE }) => {
+  const Certificate = sequelize.define(
+    'Certificate',
+    {
+      address: {
+        type   : STRING,
+        default: null,
+      },
+      amount: {
+        type   : STRING,
+        default: null,
+      },
+      claimId: {
+        type   : STRING,
+        default: null,
+      },
+      claimSequence: {
+        type   : INTEGER,
+        default: null,
+      },
+      decodedClaim: {
+        type   : BOOLEAN,
+        default: null,
+      },
+      depth: {
+        type   : INTEGER,
+        default: null,
+      },
+      effectiveAmount: {
+        type   : STRING,
+        default: null,
+      },
+      hasSignature: {
+        type   : BOOLEAN,
+        default: null,
+      },
+      height: {
+        type   : STRING,
+        default: null,
+      },
+      hex: {
+        type   : TEXT('long'),
+        default: null,
+      },
+      name: {
+        type   : STRING,
+        default: null,
+      },
+      nout: {
+        type   : INTEGER,
+        default: null,
+      },
+      txid: {
+        type   : STRING,
+        default: null,
+      },
+      validAtHeight: {
+        type   : STRING,
+        default: null,
+      },
+      outpoint: {
+        type   : STRING,
+        default: null,
+      },
+      valueVersion: {
+        type   : STRING,
+        default: null,
+      },
+      claimType: {
+        type   : STRING,
+        default: null,
+      },
+      certificateVersion: {
+        type   : STRING,
+        default: null,
+      },
+      keyType: {
+        type   : STRING,
+        default: null,
+      },
+      publicKey: {
+        type   : TEXT('long'),
+        default: null,
+      },
+    },
+    {
+      freezeTableName: true,
+    }
+  );
+  return Certificate;
+};

--- a/public/assets/css/componentStyle.css
+++ b/public/assets/css/componentStyle.css
@@ -163,7 +163,7 @@ button.copy-button {
 	overflow: auto;
 }
 
-.all-claims-img {
+.all-claims-asset {
 	width: 20%;
 	float: left;
 	margin: 5px 30px 5px 0px;
@@ -187,7 +187,7 @@ button.copy-button {
 
 @media (max-width: 750px) {
 	
-	.all-claims-img {
+	.all-claims-asset {
 		width:30%;
 	}
 
@@ -214,7 +214,7 @@ button.copy-button {
 		margin-right: 2em;
 	}
 
-    .all-claims-img {
+    .all-claims-asset {
 		width:50%;
 	}
 

--- a/routes/page-routes.js
+++ b/routes/page-routes.js
@@ -1,6 +1,6 @@
 const errorHandlers = require('../helpers/errorHandlers.js');
 const { getAllFreeClaims } = require('../helpers/serveHelpers.js');
-const { postToStats, getStatsSummary, getTrendingClaims } = require('../controllers/statsController.js');
+const { postToStats, getStatsSummary, getTrendingClaims, getRecentClaims } = require('../controllers/statsController.js');
 
 module.exports = (app) => {
   // route to show 'about' page for spee.ch
@@ -9,13 +9,26 @@ module.exports = (app) => {
     res.status(200).render('about');
   });
   // route to display a list of the trending images
-  app.get('/trending', ({ params, headers }, res) => {
+  app.get('/popular', ({ params, headers }, res) => {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - 1);
     getTrendingClaims(startDate)
       .then(result => {
         // logger.debug(result);
         res.status(200).render('trending', { trendingAssets: result });
+      })
+      .catch(error => {
+        errorHandlers.handleRequestError(error, res);
+      });
+  });
+  // route to display a list of the trending images
+  app.get('/new', ({ params, headers }, res) => {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 1);
+    getRecentClaims(startDate)
+      .then(result => {
+        // logger.debug(result);
+        res.status(200).render('new', { newClaims: result });
       })
       .catch(error => {
         errorHandlers.handleRequestError(error, res);

--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -186,7 +186,7 @@ module.exports = (app) => {
     logger.debug('claim name = ', name);
     logger.debug('method =', method);
     // 1. retrieve the asset and information
-    getAsset(CLAIM_NAME, null, null, null, name)
+    getAsset(CLAIM_NAME, null, null, null, null, name)
     // 2. serve or show
     .then(fileInfo => {
       if (!fileInfo) {

--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -151,7 +151,7 @@ module.exports = (app) => {
       logger.debug('claim name = ', name);
       logger.debug('method =', method);
       // 1. retrieve the asset and information
-      getAsset(CLAIM, null, null, null, name, null)
+      getAsset(CLAIM, null, null, name, null)
       // 2. respond to the request
       .then(fileInfo => {
         if (!fileInfo) {

--- a/routes/serve-routes.js
+++ b/routes/serve-routes.js
@@ -124,13 +124,13 @@ module.exports = (app) => {
     // parse identifier for whether it is a channel, short url, or claim_id
     if (identifier.charAt(0) === '@') {
       channelName = identifier;
-      logger.debug('channel name =', channelName);
       claimType = CHANNEL;
       const channelIdIndex = channelName.indexOf(CHANNELID_INDICATOR);
       if (channelIdIndex !== -1) {
         channelId = channelName.substring(channelIdIndex + 1);
         channelName = channelName.substring(0, channelIdIndex);
       }
+      logger.debug('channel name =', channelName);
     } else if (identifier.length === 40) {
       fullClaimId = identifier;
       logger.debug('full claim id =', fullClaimId);

--- a/views/allClaims.handlebars
+++ b/views/allClaims.handlebars
@@ -5,7 +5,7 @@
 		<p>These are all the free, public assets at that claim.  You can publish more at <a href="/">spee.ch</a>.</p>
 		{{#each claims}}
 			<div class="all-claims-item">
-				<img class="all-claims-img" src="/{{this.claimId}}/{{this.name}}.test" />
+				<img class="all-claims-asset" src="/{{this.claimId}}/{{this.name}}.test" />
 				<div class="all-claims-details">
 					<ul style="list-style-type:none">
 						<li>claim: {{this.name}}</li>

--- a/views/channel.handlebars
+++ b/views/channel.handlebars
@@ -1,0 +1,32 @@
+<div class="wrapper">
+	{{> topBar}}
+	<div>
+		<h3>{{this.channelName}}</h3>
+		<p>Below are all the free claims in this channel.</p>
+		{{#each channelContents}}
+			<div class="all-claims-item">
+				{{#ifConditional this.fileType '===' 'video/mp4'}}
+					<video class="all-claims-img" autoplay controls>
+						<source src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}">
+						{{!--fallback--}}
+						Your browser does not support the <code>video</code> element.
+					</video>
+				{{else}}
+					<img  class="all-claims-img" src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}" />
+				{{/ifConditional}}
+				
+				<div class="all-claims-details">
+					<ul style="list-style-type:none">
+						<li>Title: {{this.title}}</li>
+						<li>Description: {{this.description}}</li>
+						<li>License: {{this.license}}</li>
+						<li>Link: <a href="/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}">spee.ch/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}</a></li>
+						<li>Claim: {{this.name}}</li>
+						<li>Claim Id: {{this.claimId}}</li>
+					</ul>
+				</div>
+			</div>
+		{{/each}}
+	</div>
+	{{> footer}}
+</div>

--- a/views/channel.handlebars
+++ b/views/channel.handlebars
@@ -6,13 +6,13 @@
 		{{#each channelContents}}
 			<div class="all-claims-item">
 				{{#ifConditional this.contentType '===' 'video/mp4'}}
-					<video class="all-claims-img" autoplay controls>
+					<video class="all-claims-asset" controls>
 						<source src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}">
 						{{!--fallback--}}
 						Your browser does not support the <code>video</code> element.
 					</video>
 				{{else}}
-					<img  class="all-claims-img" src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}" />
+					<img  class="all-claims-asset" src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}" />
 				{{/ifConditional}}
 				
 				<div class="all-claims-details">

--- a/views/channel.handlebars
+++ b/views/channel.handlebars
@@ -5,22 +5,19 @@
 		<p>Below are all the free claims in this channel.</p>
 		{{#each channelContents}}
 			<div class="all-claims-item">
-				{{#ifConditional this.contentType '===' 'video/mp4'}}
-					<video class="all-claims-asset" controls>
-						<source src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}">
-						{{!--fallback--}}
-						Your browser does not support the <code>video</code> element.
-					</video>
-				{{else}}
-					<img  class="all-claims-asset" src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}" />
-				{{/ifConditional}}
-				
+				<a href="/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}">
+					{{#ifConditional this.contentType '===' 'video/mp4'}}
+						<img class="all-claims-asset" src="/assets/img/content-freedom-large.png"/>
+					{{else}}
+						<img  class="all-claims-asset" src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}" />
+					{{/ifConditional}}
+				</a>
 				<div class="all-claims-details">
 					<ul style="list-style-type:none">
-						<li>Title: {{this.title}}</li>
-						<li>Description: {{this.description}}</li>
+						<li><strong>{{this.title}}</strong></li>
+						<li><i> {{this.description}}</i></li>
+						<li><a href="/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}">spee.ch/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}</a></li>
 						<li>License: {{this.license}}</li>
-						<li>Link: <a href="/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}">spee.ch/{{this.channelName}}:{{this.shortChannelId}}/{{this.name}}.{{this.fileExtension}}</a></li>
 						<li>Claim: {{this.name}}</li>
 						<li>Claim Id: {{this.claimId}}</li>
 					</ul>

--- a/views/channel.handlebars
+++ b/views/channel.handlebars
@@ -5,7 +5,7 @@
 		<p>Below are all the free claims in this channel.</p>
 		{{#each channelContents}}
 			<div class="all-claims-item">
-				{{#ifConditional this.fileType '===' 'video/mp4'}}
+				{{#ifConditional this.contentType '===' 'video/mp4'}}
 					<video class="all-claims-img" autoplay controls>
 						<source src="/{{this.claimId}}/{{this.name}}.{{this.fileExtension}}">
 						{{!--fallback--}}

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -15,10 +15,10 @@
 	<meta property="og:image" content="https://spee.ch/assets/img/content-freedom-64px.png">
 	<meta property="og:url" content="http://spee.ch/">
 	<meta property="og:description" content="Open-source, decentralized image and video hosting.">
+	<!-- google analytics -->
+	{{ googleAnalytics }}
 </head>
 <body>
 	{{{ body }}}
-	<!-- google analytics -->
-	{{ googleAnalytics }}
 </body>
 </html>

--- a/views/layouts/show.handlebars
+++ b/views/layouts/show.handlebars
@@ -12,11 +12,11 @@
 	{{{addTwitterCard fileInfo.fileType openGraphInfo.source openGraphInfo.embedUrl openGraphInfo.directFileUrl}}}
 	{{{addOpenGraph fileInfo.title fileInfo.fileType openGraphInfo.showUrl openGraphInfo.source fileInfo.description}}}
 	{{/unless}}
+	<!-- google analytics -->
+	{{ googleAnalytics }}
 </head>
 <body>
 	{{{ body }}}
-	<!-- google analytics -->
-	{{ googleAnalytics }}
 </body>
 </html>
 

--- a/views/new.handlebars
+++ b/views/new.handlebars
@@ -1,10 +1,9 @@
-<script src="/vendors/masonry/masonry.pkgd.min.js"></script>
-
-<div class="full"> 
-	<h2>Trending</h2>
-	<p><i>The 25 most popular assets on spee.ch</i></p>
-	<div class="grid" data-masonry='{ "itemSelector": ".grid-item" }'>
-		{{#each trendingAssets}}
+<div class="wrapper">
+	{{> topBar}}
+	<div>
+		<h2>New on Spee.ch</h2>
+		<p><i>The 25 most recent publishes on spee.ch</i></p>
+		{{#each newClaims}}
 			<div class="all-claims-item">
 				<a href="/{{this.claimId}}/{{this.name}}">
 					{{#ifConditional this.fileType '===' 'video/mp4'}}
@@ -17,23 +16,11 @@
 					<ul style="list-style-type:none">
 						<li><bold>{{this.name}}</bold></li>
 						<li><i>Claim Id: {{this.claimId}}</i></li>
-						<li><strong>{{this.title}}</strong></li>
+						<li><a href="/{{this.claimId}}/{{this.name}}">Link</a></li>
 					</ul>
 				</div>
 			</div>
 		{{/each}}
 	</div>
+	{{> footer}}
 </div>
-
-
-<script>
-	var elem = document.querySelector('.grid');
-	var msnry = new Masonry( elem, {
-		itemSelector: '.grid-item'
-	});
-	
-	function resetTrendingLayout() {
-		msnry.layout();
-	}
-</script>
-

--- a/views/noChannel.handlebars
+++ b/views/noChannel.handlebars
@@ -1,0 +1,8 @@
+<div class="wrapper">
+	{{> topBar}}
+	<div>
+		<h3>No Claims</h3>
+		<p>There are no free, public assets on this channel.</p>
+		<p><i>If you think this message is an error, contact us in Slack!</i></p>
+	</div>
+</div>

--- a/views/noChannel.handlebars
+++ b/views/noChannel.handlebars
@@ -2,7 +2,7 @@
 	{{> topBar}}
 	<div>
 		<h3>No Claims</h3>
-		<p>There are no free, public assets on this channel.</p>
-		<p><i>If you think this message is an error, contact us in Slack!</i></p>
+		<p>There are no free assets on this channel.</p>
+		<p><i>If you think this message is an error, contact us in the <a href="https://lbry.slack.com/" target="_blank">LBRY slack!</a></i></p>
 	</div>
 </div>

--- a/views/noClaims.handlebars
+++ b/views/noClaims.handlebars
@@ -2,7 +2,7 @@
 	{{> topBar}}
 	<div>
 		<h3>No Claims</h3>
-		<p>There are no free, public images at that claim.  You should publish one at <a href="/">spee.ch</a>.</p>
+		<p>There are no free assets at that claim.  You should publish one at <a href="/">spee.ch</a>.</p>
 		<p>NOTE: it is possible your claim was published, but it is still being processed by the blockchain</p>
 	</div>
 </div>

--- a/views/partials/assetInfo.handlebars
+++ b/views/partials/assetInfo.handlebars
@@ -20,16 +20,6 @@
 		<input type="text" id="long-link" class="link" readonly onclick="select()" spellcheck="false" value="https://spee.ch/{{fileInfo.claimId}}/{{fileInfo.name}}{{fileInfo.fileExt}}"/>
 		<button class="copy-button" data-elementtocopy="long-link" onclick="copyToClipboard(event)">copy</button>
 	</div>
-	{{!-- gif v link --}}
-	{{#ifConditional fileInfo.fileType '===' 'video/mp4'}}
-	<div class="share-option">
-		<a href="/{{fileInfo.shortId}}/{{fileInfo.name}}.gifv">gifv</a>
-		<div class="input-error" id="input-error-copy-gifv-text" hidden="true"></div>
-		<br/>
-		<input type="text" id="gifv-text" class="link" readonly onclick="select()" spellcheck="false" value='https://spee.ch/{{fileInfo.shortId}}/{{fileInfo.name}}.gifv'/>
-		<button class="copy-button" data-elementtocopy="gifv-text" onclick="copyToClipboard(event)">copy</button>
-	</div>
-	{{/ifConditional}}
 	{{!-- html text for embedding asset--}}
 	<div class="share-option">
 		Embed HTML

--- a/views/partials/topBar.handlebars
+++ b/views/partials/topBar.handlebars
@@ -1,7 +1,6 @@
 <div class="top-bar">
 	<a href="https://en.wikipedia.org/wiki/Freedom_of_information" target="_blank"><img id="logo" src="/assets/img/content-freedom-64px.png"/></a>
 	<h1 id="title"><a href="/">Spee.ch</a></h1><span class="top-bar-left">(beta)</span>
-	<a href="/new" class="top-bar-right">new</a>
 	<a href="/popular" class="top-bar-right">popular</a>
 	<a href="https://github.com/lbryio/spee.ch" target="_blank" class="top-bar-right">source</a>
 	<a href="/about" class="top-bar-right">help</a>

--- a/views/partials/topBar.handlebars
+++ b/views/partials/topBar.handlebars
@@ -1,7 +1,8 @@
 <div class="top-bar">
 	<a href="https://en.wikipedia.org/wiki/Freedom_of_information" target="_blank"><img id="logo" src="/assets/img/content-freedom-64px.png"/></a>
 	<h1 id="title"><a href="/">Spee.ch</a></h1><span class="top-bar-left">(beta)</span>
-	<a href="/trending" class="top-bar-right">trending</a>
+	<a href="/new" class="top-bar-right">new</a>
+	<a href="/popular" class="top-bar-right">popular</a>
 	<a href="https://github.com/lbryio/spee.ch" target="_blank" class="top-bar-right">source</a>
 	<a href="/about" class="top-bar-right">help</a>
 	<div class="top-bar-tagline">Open-source, decentralized image and video hosting.</div>


### PR DESCRIPTION
added support for channel resolutions
- resolves to a list of the channels assets:
  - spee.ch/@channel
  - spee.ch/@channel:shortid
  - spee.ch/@channel:longclaimid
- resolves to a specific asset (show)
  - spee.ch/@channel/name
  - spee.ch/@channel:shortid/name
  - spee.ch/@channel:longclaimid/name
- serves an asset
  - spee.ch/@channel/name.ext
  - spee.ch/@channel:shortid/name.ext
  - spee.ch/@channel:longclaimid/name.ext

reorganized router functions

still to do: (will be a separate pr): add channel information to the asset's info page