### PR TITLE
Proposed solution to isue 159 toggleSection in Firefox

### DIFF
--- a/public/assets/js/generalFunctions.js
+++ b/public/assets/js/generalFunctions.js
@@ -3,7 +3,7 @@ function toggleSection(event){
 
 	var dataSet = event.target.dataset;
 	var status = dataSet.open;
-	var masterElement = document.getElementById(event.srcElement.id);
+	var masterElement = document.getElementById(event.target.id||event.srcElement.id);
 	var slaveElement = document.getElementById(dataSet.slaveelementid);
 	
 	if (status === "false") {


### PR DESCRIPTION
Firefox does not recognize the proprietary property 'event.srcElement'. The option to use event.target was added.