### PR TITLE
Slightly better wording (from/to)

### DIFF
--- a/views/about.handlebars
+++ b/views/about.handlebars
@@ -9,7 +9,7 @@
             </div>
         </div><div class="column column--5 column--med-10 align-content-top">
             <div class="column column--8 column--med-10">
-                <p>Spee.ch is a media-hosting site that reads and publishes content from the <a class="link--primary" href="https://lbry.io">LBRY</a> blockchain.</p>
+                <p>Spee.ch is a media-hosting site that reads from and publishes content to the <a class="link--primary" href="https://lbry.io">LBRY</a> blockchain.</p>
                 <p>Spee.ch is a hosting service, but with the added benefit that it stores your content on a decentralized network of computers -- the LBRY network.  This means that your images are stored in multiple locations without a single point of failure.</p>
                 <h3>Contribute</h3>
                 <p>If you have an idea for your own spee.ch-like site on top of LBRY, fork our <a class="link--primary" href="https://github.com/lbryio/spee.ch">github repo</a> and go to town!</p>


### PR DESCRIPTION
> Spee.ch is a media-hosting site that reads from and publishes content to the LBRY blockchain.

... reads slightly smoother than... 

> Spee.ch is a media-hosting site that reads and publishes content from the LBRY blockchain