### PR TITLE
Characters, like `ü`, `ä`, `ß` and more won't be displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ spee.ch is a single-serving site that reads and publishes images and videos to a
 * start mysql
 	* install mysql
 	* create a database called `lbry`
+	* Configure `SET NAMES 'utf8';` in the database
 	* save your connection `username` and `password` someplace handy
 * start lbrynet daemon
 	* install the [`lbry`](https://github.com/lbryio/lbry) daemon


### PR DESCRIPTION
Some characters won't display at all
![auswahl_005](https://user-images.githubusercontent.com/16866642/32413533-5c74f566-c213-11e7-9b98-d59d65a8ef49.png)
https://spee.ch/sfj2

It might be good to enable utf8 so that characters correctly.
On the lbry-app it doesn't happen somehow