### PR TITLE
general.css Video Skin Class Stlye Improvement

### DIFF
--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -520,14 +520,13 @@ table {
    	display: block;
    	margin: 0 auto;
     	background-color: #fff;
+	cursor: pointer;
 }
-#video-player {
-    	cursor: pointer;
+#showlite-body #video-player {
   	margin-top: 2%;    	
     	padding: 6px;   	
     	max-width: 50%;
 	border: 1px solid #d0d0d0;
-	box-shadow: 0 0 50px -6px rgba(0, 0, 0, 0.72);
 }
 .showlite-asset {
     	max-width: 100%;

--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -517,22 +517,20 @@ table {
 	width: 100%;
 }
 #video-player, .showlite-asset {
-    padding: 6px;
-    border: 1px solid #555;
-    background-color: #fff;
+   	display: block;
+   	margin: 0 auto;
+    	background-color: #fff;
 }
 #video-player {
-    cursor: pointer;
+    	cursor: pointer;
+  	margin-top: 2%;    	
+    	padding: 6px;   	
+    	max-width: 50%;
+	border: 1px solid #d0d0d0;
+	box-shadow: 0 0 50px -6px rgba(0, 0, 0, 0.72);
 }
-
 .showlite-asset {
-    max-width: 50%;
-    margin: 0 auto;
-    margin-top: 2%;
-    padding: 6px;
-    border: 1px solid #a2a2a2;
-//Optional Box Shadow - Looks better on a darker than white background.
-    box-shadow: 0 0 50px -6px rgba(0, 0, 0, 0.72);
+    	max-width: 100%;
 }
 
 /* item lists */

--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -516,18 +516,22 @@ table {
 	display: block;
 	width: 100%;
 }
-
-#video-player {
+#video-player, .show-asset-light {
+    padding: 6px;
+    border: 1px solid #555;
     background-color: #fff;
-    cursor: pointer;
-    margin: 0 auto;
-    margin-top: 2%;
-    border: 1px solid #d0d0d0;
-    padding:6px;
 }
-
+#video-player {
+    cursor: pointer;
+}
 .show-asset-light {
     max-width: 50%;
+    margin: 0 auto;
+    margin-top: 2%;
+    padding: 6px;
+    border: 1px solid #a2a2a2;
+//Optional Box Shadow - Looks better on a darker than white background.
+    box-shadow: 0 0 50px -6px rgba(0, 0, 0, 0.72);
 }
 
 /* item lists */


### PR DESCRIPTION
Previously, the global video element was styled to make it look better on the stand alone page. However; the class `.showasset-light` is the video skin class assigned to the stand alone page only.

Based on this, I have optimised the style on this class and removed parts no longer needed from the `video-player` class, thereby not affecting any other pages for areas only required on the stand alone page.