### PR TITLE
Wrap Long Words

### DIFF
--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -21,6 +21,7 @@ html, body {
 	margin: 0;
 	padding: 0;
 	height: 100%;
+	word-wrap: break-word;
 }
 
 body, .flex-container--column, .flex-container--row {


### PR DESCRIPTION
A global property to wrap long words/numbers so they don't fall off the screen.

`word-wrap: break-word;`