### PR TITLE
Set logo link in navbar to use pointer cursor

### DIFF
--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -466,6 +466,10 @@ table {
 	display: inline-block;
 }
 
+.nav-bar-logo {
+	cursor: pointer;
+}
+
 /* PUBLISH FORM */
 
 .dropzone {


### PR DESCRIPTION
Setting the logo link to use cursor pointer keeps things consistent with the use of user agent styling setting cursor pointer on Upload, Popular, and About links. Makes it more obvious that it's actually clickable.