### PR TITLE
In-channel publish test

### DIFF
--- a/config/speechConfig.js.example
+++ b/config/speechConfig.js.example
@@ -31,4 +31,8 @@ module.exports = {
     defaultThumbnail  : 'https://spee.ch/assets/img/video_thumb_default.png',
     defaultDescription: 'Open-source, decentralized image and video sharing.',
   },
+  testing: {
+    testChannel        : '@testpublishchannel', // a channel to make test publishes in
+    testChannelPassword: 'password',  // password for the test channel
+  },
 };

--- a/test/end-to-end/end-to-end.tests.js
+++ b/test/end-to-end/end-to-end.tests.js
@@ -1,7 +1,9 @@
 const chai = require('chai');
 const expect = chai.expect;
 const chaiHttp = require('chai-http');
-const { host } = require('../../config/speechConfig.js').site;
+const { site, testing } = require('../../config/speechConfig.js');
+const { host } = site;
+const { testChannel, testChannelPassword } = testing;
 const requestTimeout = 20000;
 const publishTimeout = 120000;
 const fs = require('fs');
@@ -88,8 +90,8 @@ describe('end-to-end', function () {
     const name = `test-publish-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}-${date.getTime()}`;
     const filePath = './test/mock-data/bird.jpeg';
     const fileName = 'byrd.jpeg';
-    const channelName = '@testpublishchannel';
-    const channelPassword = 'password';
+    const channelName = testChannel;
+    const channelPassword = testChannelPassword;
 
     describe(publishUrl, function () {
       it(`non-channel publishes should receive a status code 200 within ${publishTimeout}ms @usesLbc`, function (done) {

--- a/test/end-to-end/end-to-end.tests.js
+++ b/test/end-to-end/end-to-end.tests.js
@@ -88,14 +88,33 @@ describe('end-to-end', function () {
     const name = `test-publish-${date.getFullYear()}-${date.getMonth()}-${date.getDate()}-${date.getTime()}`;
     const filePath = './test/mock-data/bird.jpeg';
     const fileName = 'byrd.jpeg';
+    const channelName = '@testpublishchannel';
+    const channelPassword = 'password';
 
     describe(publishUrl, function () {
-      it(`should receive a status code 200 within ${publishTimeout}ms @usesLbc`, function (done) {
+      it(`non-channel publishes should receive a status code 200 within ${publishTimeout}ms @usesLbc`, function (done) {
         chai.request(host)
           .post(publishUrl)
           .type('form')
           .attach('file', fs.readFileSync(filePath), fileName)
           .field('name', name)
+          .end(function (err, res) {
+            // expect(err).to.be.null;
+            expect(res).to.have.status(200);
+            done();
+          });
+      }).timeout(publishTimeout);
+    });
+
+    describe(publishUrl, function () {
+      it(`channel publishes should receive a status code 200 within ${publishTimeout}ms @usesLbc`, function (done) {
+        chai.request(host)
+          .post(publishUrl)
+          .type('form')
+          .attach('file', fs.readFileSync(filePath), fileName)
+          .field('name', name)
+          .field('channelName', channelName)
+          .field('channelPassword', channelPassword)
           .end(function (err, res) {
             // expect(err).to.be.null;
             expect(res).to.have.status(200);


### PR DESCRIPTION
added an end-to-end test that publishes to a channel, in order to make sure in-channel publishing works and compare the response time for such publishes to non-channel publishes.