### PR TITLE
Remove the hardcoded lbry API address

### DIFF
--- a/config/speechConfig.js.example
+++ b/config/speechConfig.js.example
@@ -35,4 +35,8 @@ module.exports = {
     testChannel        : '@testpublishchannel', // a channel to make test publishes in
     testChannelPassword: 'password',  // password for the test channel
   },
+  api: {
+    apiUri: 'localhost',
+    apiPort: '5279',
+  },
 };

--- a/helpers/lbryApi.js
+++ b/helpers/lbryApi.js
@@ -1,5 +1,8 @@
 const axios = require('axios');
 const logger = require('winston');
+const config = require('../config/speechConfig.js');
+const { apiUri, apiPort } = config.api;
+const lbryApiUrl = 'http://' + apiUri + ':' + apiPort;
 
 function handleLbrynetResponse ({ data }, resolve, reject) {
   logger.debug('lbry api data:', data);
@@ -22,7 +25,7 @@ module.exports = {
     logger.debug(`lbryApi >> Publishing claim to "${publishParams.name}"`);
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'publish',
           params: publishParams,
         })
@@ -38,7 +41,7 @@ module.exports = {
     logger.debug(`lbryApi >> Getting Claim for "${uri}"`);
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'get',
           params: { uri, timeout: 20 },
         })
@@ -54,7 +57,7 @@ module.exports = {
     logger.debug(`lbryApi >> Getting claim_list for "${claimName}"`);
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'claim_list',
           params: { name: claimName },
         })
@@ -71,7 +74,7 @@ module.exports = {
     // console.log('resolving uri', uri);
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'resolve',
           params: { uri },
         })
@@ -91,7 +94,7 @@ module.exports = {
     logger.debug('lbryApi >> Retrieving the download directory path from lbry daemon...');
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'settings_get',
         })
         .then(({ data }) => {
@@ -110,7 +113,7 @@ module.exports = {
   createChannel (name) {
     return new Promise((resolve, reject) => {
       axios
-        .post('http://localhost:5279/lbryapi', {
+        .post(lbryApiUrl, {
           method: 'channel_new',
           params: {
             channel_name: name,


### PR DESCRIPTION
This fixes issue #324.
The LBRY is no longer hardcoded to localhost and is set by the config file. 

I haven't tested it. I ran into some problems while trying to install spee.ch locally on my computer.