### PR TITLE
Patch publish tool reset and asset details css

### DIFF
--- a/public/assets/css/general.css
+++ b/public/assets/css/general.css
@@ -542,10 +542,6 @@ table {
 
 /* show */
 
-.asset {
-	max-width: 100%;
-}
-
 #video {
 	cursor: pointer;
 	background-color: #ffffff;
@@ -556,15 +552,19 @@ table {
 }
 
 /* show lite */
-#show-lite-container {
+.show-lite-container {
 	text-align: center;
 }
 
-#show-lite-container #asset-display-component {
+.show-lite-container #asset-display-component {
 	max-height: calc(100vh - 3em);
 }
 
-#show-lite-container #asset-display-component .asset {
+.show-details-container #asset-display-component .asset {
+	width: 100%
+}
+
+.show-lite-container #asset-display-component .asset {
 	max-height: calc(100vh - 3em);
 	max-width: 100vw;
 }

--- a/react/components/PublishStatus/index.jsx
+++ b/react/components/PublishStatus/index.jsx
@@ -5,39 +5,39 @@ import * as publishStates from 'constants/publish_claim_states';
 
 function PublishStatus ({ status, message }) {
   return (
-    <div className="row row--tall flex-container--column flex-container--center-center">
+    <div className='row row--tall flex-container--column flex-container--center-center'>
       {(status === publishStates.LOAD_START) &&
-        <div className="row align-content-center">
+        <div className='row align-content-center'>
           <p>File is loading to server</p>
-          <p className="blue">{message}</p>
+          <p className='blue'>{message}</p>
         </div>
       }
       {(status === publishStates.LOADING) &&
       <div>
-        <div className="row align-content-center">
+        <div className='row align-content-center'>
           <p>File is loading to server</p>
-          <p className="blue">{message}</p>
+          <p className='blue'>{message}</p>
         </div>
       </div>
       }
       {(status === publishStates.PUBLISHING) &&
-      <div className="row align-content-center">
+      <div className='row align-content-center'>
         <p>Upload complete.  Your file is now being published on the blockchain...</p>
-        <ProgressBar size={12}/>
-        <p>Curious what magic is happening here? <a className="link--primary" target="blank" href="https://lbry.io/faq/what-is-lbry">Learn more.</a></p>
+        <ProgressBar size={12} />
+        <p>Curious what magic is happening here? <a className='link--primary' target='blank' href='https://lbry.io/faq/what-is-lbry'>Learn more.</a></p>
       </div>
       }
       {(status === publishStates.SUCCESS) &&
-      <div className="row align-content-center">
+      <div className='row align-content-center'>
         <p>Your publish is complete! You are being redirected to it now.</p>
-        <p>If you are not automatically redirected, <a className="link--primary" target="_blank" href={message}>click here.</a></p>
+        <p>If you are not automatically redirected, <a className='link--primary' target='_blank' href={message}>click here.</a></p>
       </div>
       }
       {(status === publishStates.FAILED) &&
-      <div className="row align-content-center">
+      <div className='row align-content-center'>
         <p>Something went wrong...</p>
         <p><strong>{message}</strong></p>
-        <p>For help, post the above error text in the #speech channel on the <a className="link--primary" href="https://discord.gg/YjYbwhS" target="_blank">lbry discord</a></p>
+        <p>For help, post the above error text in the #speech channel on the <a className='link--primary' href='https://discord.gg/YjYbwhS' target='_blank'>lbry discord</a></p>
       </div>
       }
     </div>

--- a/react/components/ShowAssetDetails/view.jsx
+++ b/react/components/ShowAssetDetails/view.jsx
@@ -20,7 +20,7 @@ class ShowAssetDetails extends React.Component {
               <AssetTitle />
             </div>
             <div className='column column--5 column--sml-10 align-content-top'>
-              <div className='row row--padded'>
+              <div className='row row--padded show-details-container'>
                 <AssetDisplay />
               </div>
             </div><div className='column column--5 column--sml-10 align-content-top'>

--- a/react/components/ShowAssetLite/view.jsx
+++ b/react/components/ShowAssetLite/view.jsx
@@ -9,7 +9,7 @@ class ShowLite extends React.Component {
     if (asset) {
       const { name, claimId } = asset.claimData;
       return (
-        <div id='show-lite-container' className='row row--tall flex-container--column flex-container--center-center'>
+        <div className='row row--tall flex-container--column flex-container--center-center show-lite-container'>
           <SEO pageTitle={name} asset={asset} />
           <AssetDisplay />
           <Link id='asset-boilerpate' className='link--primary fine-print' to={`/${claimId}/${name}`}>hosted

--- a/react/containers/PublishForm/view.jsx
+++ b/react/containers/PublishForm/view.jsx
@@ -72,7 +72,7 @@ class PublishForm extends React.Component {
         console.log('publish response:', response);
         if ((xhr.status === 200) && response.success) {
           this.props.history.push(`/${response.data.claimId}/${response.data.name}`);
-          this.props.onPublishStatusChange(publishStates.SUCCESS, response.data.url);
+          this.props.onFileClear();
         } else {
           this.props.onPublishStatusChange(publishStates.FAILED, response.message);
         }
@@ -118,9 +118,6 @@ class PublishForm extends React.Component {
         const metadata = this.createMetadata();
         // publish the claim
         return this.makePublishRequest(this.props.file, metadata);
-      })
-      .then(() => {
-        this.props.onPublishStatusChange('publish request made');
       })
       .catch((error) => {
         this.props.onPublishSubmitError(error.message);


### PR DESCRIPTION
a couple patches from last merge into master:
- the publish tool was not being reset after a completed publish
- the asset was not being scaled to take the full width of its container on the details page