### PR TITLE
refactor(google analytics): split ga timing events into multiple categories

### DIFF
--- a/helpers/googleAnalytics.js
+++ b/helpers/googleAnalytics.js
@@ -13,11 +13,11 @@ function createServeEventParams (headers, ip, originalUrl) {
 };
 
 function createPublishTimingEventParams (category, variable, label, startTime, endTime) {
-  const durration = endTime - startTime;
+  const duration = endTime - startTime;
   return {
     userTimingCategory    : category,
     userTimingVariableName: variable,
-    userTimingTime        : durration,
+    userTimingTime        : duration,
     userTimingLabel       : label,
   };
 };
@@ -51,10 +51,7 @@ module.exports = {
     const params = createPublishTimingEventParams(category, variable, label, startTime, endTime);
     sendGoogleAnalyticsTiming(siteName, params);
   },
-  chooseGaLbrynetPublishLabel (publishParams) {
-    if (publishParams.channel_name || publishParams.channel_id) {
-      return 'PUBLISH_IN_CHANNEL_CLAIM';
-    }
-    return 'PUBLISH_ANONYMOUS_CLAIM';
+  chooseGaLbrynetPublishLabel ({ channel_name: channelName, channel_id: channelId }) {
+    return (channelName || channelId ? 'PUBLISH_IN_CHANNEL_CLAIM' : 'PUBLISH_ANONYMOUS_CLAIM');
   },
 };

--- a/helpers/googleAnalytics.js
+++ b/helpers/googleAnalytics.js
@@ -51,7 +51,7 @@ module.exports = {
     const params = createPublishTimingEventParams(category, variable, label, startTime, endTime);
     sendGoogleAnalyticsTiming(siteName, params);
   },
-  chooseGaPublishLabel (publishParams) {
+  chooseGaLbrynetPublishLabel (publishParams) {
     if (publishParams.channel_name || publishParams.channel_id) {
       return 'PUBLISH_IN_CHANNEL_CLAIM';
     }

--- a/helpers/googleAnalytics.js
+++ b/helpers/googleAnalytics.js
@@ -53,8 +53,8 @@ module.exports = {
   },
   chooseGaPublishLabel (publishParams) {
     if (publishParams.channel_name || publishParams.channel_id) {
-      return 'PUBLISH_IN_CHANNEL';
+      return 'PUBLISH_IN_CHANNEL_CLAIM';
     }
-    return 'PUBLISH_ANONYMOUS';
+    return 'PUBLISH_ANONYMOUS_CLAIM';
   },
 };

--- a/helpers/lbryApi.js
+++ b/helpers/lbryApi.js
@@ -3,8 +3,9 @@ const logger = require('winston');
 const config = require('../config/speechConfig.js');
 const { apiHost, apiPort } = config.api;
 const lbryApiUri = 'http://' + apiHost + ':' + apiPort;
+const { chooseGaPublishLabel, sendGATimingEvent } = require('./googleAnalytics.js');
 
-function handleLbrynetResponse ({ data }, resolve, reject) {
+const handleLbrynetResponse = ({ data }, resolve, reject) => {
   logger.debug('lbry api data:', data);
   if (data.result) {
     // check for an error
@@ -18,11 +19,12 @@ function handleLbrynetResponse ({ data }, resolve, reject) {
   }
   // fallback in case it just timed out
   reject(JSON.stringify(data));
-}
+};
 
 module.exports = {
   publishClaim (publishParams) {
     logger.debug(`lbryApi >> Publishing claim to "${publishParams.name}"`);
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
@@ -30,6 +32,7 @@ module.exports = {
           params: publishParams,
         })
         .then(response => {
+          sendGATimingEvent('lbrynet', 'publish', chooseGaPublishLabel(publishParams), gaStartTime, Date.now());
           handleLbrynetResponse(response, resolve, reject);
         })
         .catch(error => {
@@ -39,6 +42,7 @@ module.exports = {
   },
   getClaim (uri) {
     logger.debug(`lbryApi >> Getting Claim for "${uri}"`);
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
@@ -46,6 +50,7 @@ module.exports = {
           params: { uri, timeout: 20 },
         })
         .then(response => {
+          sendGATimingEvent('lbrynet', 'getClaim', 'GET', gaStartTime, Date.now());
           handleLbrynetResponse(response, resolve, reject);
         })
         .catch(error => {
@@ -55,6 +60,7 @@ module.exports = {
   },
   getClaimList (claimName) {
     logger.debug(`lbryApi >> Getting claim_list for "${claimName}"`);
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
@@ -62,6 +68,7 @@ module.exports = {
           params: { name: claimName },
         })
         .then(response => {
+          sendGATimingEvent('lbrynet', 'getClaimList', 'CLAIM_LIST', gaStartTime, Date.now());
           handleLbrynetResponse(response, resolve, reject);
         })
         .catch(error => {
@@ -71,6 +78,7 @@ module.exports = {
   },
   resolveUri (uri) {
     logger.debug(`lbryApi >> Resolving URI for "${uri}"`);
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
@@ -78,6 +86,7 @@ module.exports = {
           params: { uri },
         })
         .then(({ data }) => {
+          sendGATimingEvent('lbrynet', 'resolveUri', 'RESOLVE', gaStartTime, Date.now());
           if (data.result[uri].error) {  // check for errors
             reject(data.result[uri].error);
           } else {  // if no errors, resolve
@@ -91,12 +100,14 @@ module.exports = {
   },
   getDownloadDirectory () {
     logger.debug('lbryApi >> Retrieving the download directory path from lbry daemon...');
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
           method: 'settings_get',
         })
         .then(({ data }) => {
+          sendGATimingEvent('lbrynet', 'getDownloadDirectory', 'SETTINGS_GET', gaStartTime, Date.now());
           if (data.result) {
             resolve(data.result.download_directory);
           } else {
@@ -110,6 +121,8 @@ module.exports = {
     });
   },
   createChannel (name) {
+    logger.debug(`lbryApi >> Creating channel for ${name}...`);
+    const gaStartTime = Date.now();
     return new Promise((resolve, reject) => {
       axios
         .post(lbryApiUri, {
@@ -120,11 +133,10 @@ module.exports = {
           },
         })
         .then(response => {
-          logger.verbose('createChannel response:', response);
+          sendGATimingEvent('lbrynet', 'createChannel', 'CHANNEL_NEW', gaStartTime, Date.now());
           handleLbrynetResponse(response, resolve, reject);
         })
         .catch(error => {
-          logger.error('createChannel error:', error);
           reject(error);
         });
     });

--- a/helpers/lbryApi.js
+++ b/helpers/lbryApi.js
@@ -3,7 +3,7 @@ const logger = require('winston');
 const config = require('../config/speechConfig.js');
 const { apiHost, apiPort } = config.api;
 const lbryApiUri = 'http://' + apiHost + ':' + apiPort;
-const { chooseGaPublishLabel, sendGATimingEvent } = require('./googleAnalytics.js');
+const { chooseGaLbrynetPublishLabel, sendGATimingEvent } = require('./googleAnalytics.js');
 
 const handleLbrynetResponse = ({ data }, resolve, reject) => {
   logger.debug('lbry api data:', data);
@@ -32,7 +32,7 @@ module.exports = {
           params: publishParams,
         })
         .then(response => {
-          sendGATimingEvent('lbrynet', 'publish', chooseGaPublishLabel(publishParams), gaStartTime, Date.now());
+          sendGATimingEvent('lbrynet', 'publish', chooseGaLbrynetPublishLabel(publishParams), gaStartTime, Date.now());
           handleLbrynetResponse(response, resolve, reject);
         })
         .catch(error => {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -175,7 +175,7 @@ module.exports = (app) => {
           },
         });
         // record the publish end time and send to google analytics
-        sendGATimingEvent('end-to-end', 'publish', 'publish endpoint', gaStartTime, Date.now());
+        sendGATimingEvent('end-to-end', 'publish', fileType, gaStartTime, Date.now());
       })
       .catch(error => {
         errorHandlers.handleErrorResponse(originalUrl, ip, error, res);

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -7,7 +7,7 @@ const { claimNameIsAvailable, checkChannelAvailability, publish } = require('../
 const { getClaimList, resolveUri, getClaim } = require('../helpers/lbryApi.js');
 const { addGetResultsToFileData, createBasicPublishParams, createThumbnailPublishParams, parsePublishApiRequestBody, parsePublishApiRequestFiles, createFileData } = require('../helpers/publishHelpers.js');
 const errorHandlers = require('../helpers/errorHandlers.js');
-const { sendGAAnonymousPublishTiming, sendGAChannelPublishTiming } = require('../helpers/googleAnalytics.js');
+const { sendGATimingEvent } = require('../helpers/googleAnalytics.js');
 const { authenticateUser } = require('../auth/authentication.js');
 const { getChannelData, getChannelClaims, getClaimId } = require('../controllers/serveController.js');
 
@@ -131,9 +131,9 @@ module.exports = (app) => {
     logger.debug('api/claim/publish req.body:', body);
     logger.debug('api/claim/publish req.files:', files);
     // define variables
-    let  name, fileName, filePath, fileType, thumbnailFileName, thumbnailFilePath, thumbnailFileType, nsfw, license, title, description, thumbnail, channelName, channelId, channelPassword;
+    let  channelName, channelId, channelPassword, description, fileName, filePath, fileType, gaStartTime, license, name, nsfw, thumbnail, thumbnailFileName, thumbnailFilePath, thumbnailFileType, title;
     // record the start time of the request
-    const publishStartTime = Date.now();
+    gaStartTime = Date.now();
     // validate the body and files of the request
     try {
       // validateApiPublishRequest(body, files);
@@ -175,12 +175,7 @@ module.exports = (app) => {
           },
         });
         // record the publish end time and send to google analytics
-        const publishEndTime = Date.now();
-        if (channelName) {
-          sendGAChannelPublishTiming(headers, ip, originalUrl, publishStartTime, publishEndTime);
-        } else {
-          sendGAAnonymousPublishTiming(headers, ip, originalUrl, publishStartTime, publishEndTime);
-        }
+        sendGATimingEvent('end-to-end', 'publish', 'publish endpoint', gaStartTime, Date.now());
       })
       .catch(error => {
         errorHandlers.handleErrorResponse(originalUrl, ip, error, res);


### PR DESCRIPTION
in order to sharpen the google analytics surrounding events, I broke the events into two categories:
1. 'end-to-end' events which measure the time from receiving a request at the api endpoint to the time a response is issued to the client. (currently covers the publish api endpoint, with labels by file type)
2. 'lbrynet' events which measure the time from when a request is made to the daemon the time when the response is received from the daemon. (expanded these events with a label for each daemon action)