### PR TITLE
Adding Border Back to Videos

### DIFF
--- a/client/scss/components/_asset-display.scss
+++ b/client/scss/components/_asset-display.scss
@@ -10,3 +10,8 @@
   max-height: 100%;
   margin : 0;
 }
+.asset-video {
+  margin: 16px;
+  padding: 6px;
+  border: 1px solid #d0d0d0;
+}


### PR DESCRIPTION
Video border was lost in recent [PR](https://github.com/lbryio/spee.ch/pull/471) This adds it back.