### PR TITLE
Border Removed From Video Thumbs

### DIFF
--- a/client/scss/components/_asset-preview.scss
+++ b/client/scss/components/_asset-preview.scss
@@ -8,7 +8,4 @@
   cursor: pointer;
   background-color: #ffffff;
   width: calc(100% - 12px - 12px - 2px);
-  margin: 6px;
-  padding: 6px;
-  border: 1px solid #d0d0d0;
 }


### PR DESCRIPTION
Borders were accidentally added to video thumbs in a recent [PR](https://github.com/lbryio/spee.ch/pull/471/files). This removes them.