### PR TITLE
changed social bot list to array

### DIFF
--- a/server/controllers/assets/utils/determineRequestType.js
+++ b/server/controllers/assets/utils/determineRequestType.js
@@ -3,26 +3,32 @@ const { EMBED, BROWSER, SOCIAL } = require('../constants/request_types.js');
 
 function headersMatchesSocialBotList (headers) {
   const userAgent = headers['user-agent'];
-  const socialBotList = {
-    'facebookexternalhit': 1,
-    'Twitterbot'         : 1,
-  };
-  return socialBotList[userAgent];
+  const socialBotList = [
+    'facebookexternalhit',
+    'Twitterbot',
+  ];
+  for (let i = 0; i < socialBotList.length; i++) {
+    if (userAgent.indexOf(socialBotList[i]) >= 0) {
+      logger.debug('request is from social bot:', socialBotList[i]);
+      return true;
+    }
+  }
+  return false;
 }
 
 function clientAcceptsHtml ({accept}) {
   return accept && accept.match(/text\/html/);
-};
+}
 
 function requestIsFromBrowser (headers) {
   return headers['user-agent'] && headers['user-agent'].match(/Mozilla/);
-};
+}
 
 function clientWantsAsset ({accept, range}) {
   const imageIsWanted = accept && accept.match(/image\/.*/) && !accept.match(/text\/html/) && !accept.match(/text\/\*/);
   const videoIsWanted = accept && range;
   return imageIsWanted || videoIsWanted;
-};
+}
 
 const determineRequestType = (hasFileExtension, headers) => {
   let responseType;

--- a/server/controllers/assets/utils/determineRequestType.js
+++ b/server/controllers/assets/utils/determineRequestType.js
@@ -8,7 +8,7 @@ function headersMatchesSocialBotList (headers) {
     'Twitterbot',
   ];
   for (let i = 0; i < socialBotList.length; i++) {
-    if (userAgent.indexOf(socialBotList[i]) >= 0) {
+    if (userAgent.includes(socialBotList[i])) {
       logger.debug('request is from social bot:', socialBotList[i]);
       return true;
     }

--- a/server/middleware/torCheckMiddleware.js
+++ b/server/middleware/torCheckMiddleware.js
@@ -12,7 +12,6 @@ const torCheck = (req, res, next) => {
       raw: true,
     })
     .then(result => {
-      logger.debug('tor check results:', result);
       if (result.length >= 1) {
         logger.info('Tor request blocked:', ip);
         const failureResponse = {


### PR DESCRIPTION
changing social bot check back to an array instead of object, because the check needs to be non-exact.
in the below code, it only returns true if the user agent string is an exact match
```
const socialBotList = {
    'facebookexternalhit': 1,
    'Twitterbot': 1,
}
​
if (socialBotList[userAgent]) {
  logger.debug();
  return true;
} else {
  return false;
}
```
in the below version, it will catch any string that contains the social bot name.  e.g. ` facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_u
atext.php)` or `Twitterbot/1.0`.  This will mean a change to `Twitterbot/2.0` or related will not require a change in this code.
```
const socialBotList = [
  'facebookexternalhit',
  'Twitterbot',
];
for (let i = 0; i < socialBotList.length; i++) {
  if (userAgent.indexOf(socialBotList[i]) >= 0) {
    logger.debug('request is from social bot:', socialBotList[i]);
    return true;
  }
}
```
