### PR TITLE
fix app thumbnail viewing on spee.ch

### DIFF
--- a/client/build/components/AssetPreview/index.js
+++ b/client/build/components/AssetPreview/index.js
@@ -19,7 +19,7 @@ var AssetPreview = function AssetPreview(_ref) {
       fileExt = _ref$claimData.fileExt,
       contentType = _ref$claimData.contentType,
       thumbnail = _ref$claimData.thumbnail;
-  var directSourceLink = "".concat(claimId, "/").concat(name, ".").concat(fileExt);
+  var directSourceLink = "asset/".concat(name, "/").concat(claimId);
   var showUrlLink = "/".concat(claimId, "/").concat(name);
   return _react.default.createElement(_reactRouterDom.Link, {
     to: showUrlLink

--- a/client/build/containers/AssetDisplay/view.js
+++ b/client/build/containers/AssetDisplay/view.js
@@ -82,7 +82,7 @@ function (_React$Component) {
           case 'image/gif':
             return _react.default.createElement("img", {
               className: "asset-image",
-              src: "/".concat(claimId, "/").concat(name, ".").concat(fileExt),
+              src: "/asset/".concat(name, "/").concat(claimId),
               alt: name
             });
 
@@ -92,7 +92,7 @@ function (_React$Component) {
               controls: true,
               poster: thumbnail
             }, _react.default.createElement("source", {
-              src: "/".concat(claimId, "/").concat(name, ".").concat(fileExt)
+              src: "/asset/".concat(name, "/").concat(claimId)
             }), _react.default.createElement("p", null, "Your browser does not support the ", _react.default.createElement("code", null, "video"), " element."));
 
           default:

--- a/client/src/components/AssetPreview/index.jsx
+++ b/client/src/components/AssetPreview/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, contentType, thumbnail } }) => {
-  const directSourceLink = `${claimId}/${name}.${fileExt}`;
+  const directSourceLink = `asset/${name}/${claimId}`;
   const showUrlLink = `/${claimId}/${name}`;
   return (
     <Link to={showUrlLink} >

--- a/client/src/containers/AssetDisplay/view.jsx
+++ b/client/src/containers/AssetDisplay/view.jsx
@@ -39,7 +39,7 @@ class AssetDisplay extends React.Component {
               return (
                 <img
                   className='asset-image'
-                  src={`/${claimId}/${name}.${fileExt}`}
+                  src={`/asset/${name}/${claimId}`}
                   alt={name}
                 />
               );
@@ -49,7 +49,9 @@ class AssetDisplay extends React.Component {
                   className='asset-video'
                   controls poster={thumbnail}
                 >
-                  <source src={`/${claimId}/${name}.${fileExt}`} />
+                  <source
+                    src={`/asset/${name}/${claimId}`}
+                  />
                   <p>Your browser does not support the <code>video</code> element.</p>
                 </video>
               );

--- a/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
+++ b/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
@@ -12,9 +12,18 @@ const parsePublishApiRequestFiles = ({file, thumbnail}) => {
     throw new Error('no file type found');
   }
   if (!file.size) {
-    throw new Error('no file type found');
+    throw new Error('no file size found');
   }
   // validate the file name
+  if (!file.name) {
+    throw new Error('no file name found');
+  }
+  if (file.name.indexOf('.') < 0) {
+    throw new Error('no file extension found in file name');
+  }
+  if (file.name.indexOf('.') === 0) {
+    throw new Error('file name cannot start with "."');
+  }
   if (/'/.test(file.name)) {
     throw new Error('apostrophes are not allowed in the file name');
   }

--- a/server/controllers/api/claim/publish/validateFileTypeAndSize.js
+++ b/server/controllers/api/claim/publish/validateFileTypeAndSize.js
@@ -1,6 +1,7 @@
 const logger = require('winston');
 
 const validateFileTypeAndSize = (file) => {
+  logger.debug('FILE:', file);
   // check file type and size
   switch (file.type) {
     case 'image/jpeg':
@@ -27,6 +28,7 @@ const validateFileTypeAndSize = (file) => {
       logger.debug('publish > file validation > unrecognized file type');
       throw new Error('The ' + file.type + ' content type is not supported.  Only, .jpeg, .png, .gif, and .mp4 files are currently supported.');
   }
+  // check file name
   return file;
 };
 

--- a/server/controllers/api/claim/publish/validateFileTypeAndSize.js
+++ b/server/controllers/api/claim/publish/validateFileTypeAndSize.js
@@ -1,7 +1,6 @@
 const logger = require('winston');
 
 const validateFileTypeAndSize = (file) => {
-  logger.debug('FILE:', file);
   // check file type and size
   switch (file.type) {
     case 'image/jpeg':
@@ -26,9 +25,8 @@ const validateFileTypeAndSize = (file) => {
       break;
     default:
       logger.debug('publish > file validation > unrecognized file type');
-      throw new Error('The ' + file.type + ' content type is not supported.  Only, .jpeg, .png, .gif, and .mp4 files are currently supported.');
+      throw new Error('The ' + file.type + ' content type is not supported.  Only, .jpg, .png, .gif, and .mp4 files are currently supported.');
   }
-  // check file name
   return file;
 };
 

--- a/server/controllers/api/claim/publish/validateFileTypeAndSize.js
+++ b/server/controllers/api/claim/publish/validateFileTypeAndSize.js
@@ -25,7 +25,7 @@ const validateFileTypeAndSize = (file) => {
       break;
     default:
       logger.debug('publish > file validation > unrecognized file type');
-      throw new Error('The ' + file.type + ' content type is not supported.  Only, .jpg, .png, .gif, and .mp4 files are currently supported.');
+      throw new Error('The ' + file.type + ' content type is not supported.  Only, image/jpg, image/png, image/gif, and video/mp4 content types are currently supported.');
   }
   return file;
 };

--- a/server/controllers/assets/utils/serveFile.js
+++ b/server/controllers/assets/utils/serveFile.js
@@ -1,13 +1,16 @@
 const logger = require('winston');
 
 const serveFile = ({ filePath, fileType }, res) => {
-  logger.verbose(`serving file: ${filePath}`);
+  if (!fileType) {
+    logger.error(`no fileType provided for ${filePath}`);
+  }
   const sendFileOptions = {
     headers: {
       'X-Content-Type-Options': 'nosniff',
-      'Content-Type'          : fileType || 'image/jpeg',
+      'Content-Type'          : fileType,
     },
   };
+  logger.debug(`fileOptions for ${filePath}:`, sendFileOptions);
   res.status(200).sendFile(filePath, sendFileOptions);
 };
 

--- a/server/views/embed.handlebars
+++ b/server/views/embed.handlebars
@@ -1,1 +1,1 @@
-<video width="100%" controls src="{{host}}/{{claimId}}/{{name}}.mp4" type="video/mp4"></video>
+<video width="100%" controls src="{{host}}/asset/{{name}}/{{claimId}}" type="video/mp4"></video>


### PR DESCRIPTION
This PR fixes the issue where spee.ch was showing a page with a broken link instead of the asset.  This issues seems to have been a result of cloudflare caching the page document and serving that instead of the image or video. 
- added check for file name in publish request
- fixed accuracy of some file check error messages
- remove default content type of `image/jpeg` on file serving
- changed embeded assets to use the `spee.ch/asset/<name>/<claimid>` route which is specific for serving the asset itself, thus avoiding the confusion which lead to cloudflare serving the document from the cache