### PR TITLE
Fixes Missing Line & Stop Content Touchings Sides

### DIFF
--- a/client/scss/_text.scss
+++ b/client/scss/_text.scss
@@ -20,6 +20,7 @@ h3 {
 p, body, button, input, textarea, label, select, option {
   font-family: 'Lekton', monospace;
   font-size: $text-large;
+  padding:10px;
 }
 
 .text--extra-large {


### PR DESCRIPTION
Fixes missing Line in the header and stops content touchings sides with the other fixes.

![image](https://user-images.githubusercontent.com/29914179/42702102-cc6752ca-870b-11e8-89b8-5e661f2a6898.png)

![image](https://user-images.githubusercontent.com/29914179/42701992-6ec987d2-870b-11e8-9b38-f45cf398a559.png)
![image](https://user-images.githubusercontent.com/29914179/42702022-89eebe2e-870b-11e8-9045-b08620a5b643.png)
