### PR TITLE
Margin Breaks Flex Vertical Alignment

### DIFF
--- a/client/scss/components/_page-layout-show-lite.scss
+++ b/client/scss/components/_page-layout-show-lite.scss
@@ -2,7 +2,7 @@
   flex: 1 0 auto;
   display: flex;
   flex-direction: column;
-  margin: $primary-padding;
+  /*margin: $primary-padding;*/
   .content {
     flex: 1 0 auto;
     display: flex;


### PR DESCRIPTION
Removing the marking fixes vertical alignment issues when using Flex.