### PR TITLE
updated serve and show urls in publish response

### DIFF
--- a/server/controllers/api/claim/publish/index.js
+++ b/server/controllers/api/claim/publish/index.js
@@ -27,6 +27,7 @@ const claimPublish = ({ body, files, headers, ip, originalUrl, user, tor }, res)
     ip,
     headers,
     body,
+    files,
   });
   // check for disabled publishing
   if (disabled) {
@@ -36,14 +37,14 @@ const claimPublish = ({ body, files, headers, ip, originalUrl, user, tor }, res)
     });
   }
   // define variables
-  let  channelName, channelId, channelPassword, description, fileName, filePath, fileType, gaStartTime, license, name, nsfw, thumbnail, thumbnailFileName, thumbnailFilePath, thumbnailFileType, title;
+  let  channelName, channelId, channelPassword, description, fileName, filePath, fileExtension, fileType, gaStartTime, license, name, nsfw, thumbnail, thumbnailFileName, thumbnailFilePath, thumbnailFileType, title;
   // record the start time of the request
   gaStartTime = Date.now();
   // validate the body and files of the request
   try {
     // validateApiPublishRequest(body, files);
     ({name, nsfw, license, title, description, thumbnail} = parsePublishApiRequestBody(body));
-    ({fileName, filePath, fileType, thumbnailFileName, thumbnailFilePath, thumbnailFileType} = parsePublishApiRequestFiles(files));
+    ({fileName, filePath, fileExtension, fileType, thumbnailFileName, thumbnailFilePath, thumbnailFileType} = parsePublishApiRequestFiles(files));
     ({channelName, channelId, channelPassword} = body);
   } catch (error) {
     return res.status(400).json({success: false, message: error.message});
@@ -76,8 +77,9 @@ const claimPublish = ({ body, files, headers, ip, originalUrl, user, tor }, res)
         data   : {
           name,
           claimId : result.claim_id,
-          url : `${host}/${result.claim_id}/${name}`,
-          embedUrl: `${host}/asset/${name}/${result.claim_id}`,
+          url : `${host}/${result.claim_id}/${name}`, // for backwards compatability with app
+          showUrl : `${host}/${result.claim_id}/${name}`,
+          serveUrl: `${host}/${result.claim_id}/${name}${fileExtension}`,
           lbryTx  : result,
         },
       });

--- a/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
+++ b/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const validateFileTypeAndSize = require('./validateFileTypeAndSize.js');
 
 const parsePublishApiRequestFiles = ({file, thumbnail}) => {
@@ -33,6 +34,7 @@ const parsePublishApiRequestFiles = ({file, thumbnail}) => {
   return {
     fileName         : file.name,
     filePath         : file.path,
+    fileExtension    : path.extname(file.path),
     fileType         : file.type,
     thumbnailFileName: (thumbnail ? thumbnail.name : null),
     thumbnailFilePath: (thumbnail ? thumbnail.path : null),


### PR DESCRIPTION
updating the publish api response to include both the `show` and `serve` urls for an asset