### PR TITLE
updated Claim model to return proper error if no matching claim id found

### DIFF
--- a/server/controllers/assets/serveByIdentifierAndClaim/index.js
+++ b/server/controllers/assets/serveByIdentifierAndClaim/index.js
@@ -36,7 +36,16 @@ const serverByIdentifierAndClaim = (req, res) => {
       [claimId, claimName] = flipClaimNameAndId(claimId, claimName);
     }
 
-    logger.debug('serve request:', { headers, ip, originalUrl, params });
+    logger.debug('serve request:', {
+      headers,
+      ip,
+      originalUrl,
+      params,
+      channelName,
+      channelClaimId,
+      claimName,
+      claimId,
+    });
 
     getClaimIdAndServeAsset(channelName, channelClaimId, claimName, claimId, originalUrl, ip, res);
 

--- a/server/controllers/utils/getClaimId.js
+++ b/server/controllers/utils/getClaimId.js
@@ -3,27 +3,19 @@ const logger = require('winston');
 const db = require('../../models/index');
 
 const getClaimIdByChannel = (channelName, channelClaimId, claimName) => {
-  return new Promise((resolve, reject) => {
-    db.Certificate
-      .getLongChannelId(channelName, channelClaimId)
-      .then(longChannelId => {
-        return db.Claim.getClaimIdByLongChannelId(longChannelId, claimName);
-      })
-      .then(longClaimId => {
-        resolve(longClaimId);
-      })
-      .catch(error => {
-        reject(error);
-      });
-  });
+  logger.debug(`getClaimIdByChannel(${channelName}, ${channelClaimId}, ${claimName})`);
+  return db.Certificate
+    .getLongChannelId(channelName, channelClaimId)
+    .then(longChannelId => {
+      return db.Claim.getClaimIdByLongChannelId(longChannelId, claimName);
+    });
 };
 
 const getClaimId = (channelName, channelClaimId, name, claimId) => {
+  logger.debug(`getClaimId: ${channelName}, ${channelClaimId}, ${name}, ${claimId})`);
   if (channelName) {
-    logger.debug(`getClaimIdByChannel(${channelName}, ${channelClaimId}, ${name})`);
     return getClaimIdByChannel(channelName, channelClaimId, name);
   } else {
-    logger.debug(`db.Claim.getLongClaimId(${name}, ${claimId})`);
     return db.Claim.getLongClaimId(name, claimId);
   }
 };

--- a/server/models/claim.js
+++ b/server/models/claim.js
@@ -260,11 +260,11 @@ module.exports = (sequelize, { STRING, BOOLEAN, INTEGER, TEXT, DECIMAL }) => {
         .then(result => {
           switch (result.length) {
             case 0:
-              return resolve(null);
+              return reject(NO_CLAIM);
             case 1:
               return resolve(result[0].claimId);
             default:
-              logger.error(`${result.length} records found for "${claimName}" in channel "${channelClaimId}"`);
+              logger.warn(`${result.length} records found for "${claimName}" in channel "${channelClaimId}"`);
               return resolve(result[0].claimId);
           }
         })
@@ -344,7 +344,7 @@ module.exports = (sequelize, { STRING, BOOLEAN, INTEGER, TEXT, DECIMAL }) => {
   };
 
   Claim.getLongClaimId = function (claimName, claimId) {
-    // logger.debug(`getLongClaimId(${claimName}, ${claimId})`);
+    logger.debug(`getLongClaimId(${claimName}, ${claimId})`);
     if (isLongClaimId(claimId)) {
       return this.validateLongClaimId(claimName, claimId);
     } else if (isShortClaimId(claimId)) {
@@ -379,6 +379,7 @@ module.exports = (sequelize, { STRING, BOOLEAN, INTEGER, TEXT, DECIMAL }) => {
   };
 
   Claim.getOutpoint = function (name, claimId) {
+    logger.debug(`finding outpoint for ${name}#${claimId}`);
     return this
       .findAll({
         where     : { name, claimId },


### PR DESCRIPTION
updated `Claim.getClaimIdByLongChannelId` to reject with `NO_CLAIM` if a `claim id` is not found