### PR TITLE
return default block height of 100000

### DIFF
--- a/server/controllers/api/claim/publish/publish.js
+++ b/server/controllers/api/claim/publish/publish.js
@@ -44,7 +44,8 @@ const publish = (publishParams, fileName, fileType) => {
       })
       .then(([fileRecord, claimRecord]) => {
         // upsert the records
-        const {name, claim_id: claimId} = publishParams;
+        const {name} = publishParams;
+        const {claim_id: claimId} = publishResults;
         const upsertCriteria = {
           name,
           claimId,

--- a/server/models/claim.js
+++ b/server/models/claim.js
@@ -403,8 +403,19 @@ module.exports = (sequelize, { STRING, BOOLEAN, INTEGER, TEXT, DECIMAL }) => {
   };
 
   Claim.getCurrentHeight = function () {
-    return this
-      .max('height');
+    return new Promise((resolve, reject) => {
+      return this
+        .max('height')
+        .then(result => {
+          if (result) {
+            return resolve(result);
+          }
+          return resolve(100000);
+        })
+        .catch(error => {
+          return reject(error);
+        });
+    });
   };
 
   return Claim;


### PR DESCRIPTION
A new spee.ch instance has no claims in its db so the max height is `NaN` which throws an error. This default value will be overridden when synced.