### PR TITLE
Fix content-type and file extensions (enforce image/jpeg and .jpg)

### DIFF
--- a/client/src/utils/determineContentTypeFromExtension.js
+++ b/client/src/utils/determineContentTypeFromExtension.js
@@ -4,7 +4,7 @@ const determineContentTypeFromExtension = (thumbnail) => {
     switch (fileExt) {
       case 'jpeg':
       case 'jpg':
-        return 'image/jpg';
+        return 'image/jpeg';
       case 'png':
         return 'image/png';
       case 'gif':

--- a/server/models/claim.js
+++ b/server/models/claim.js
@@ -8,7 +8,7 @@ function determineFileExtensionFromContentType (contentType) {
   switch (contentType) {
     case 'image/jpeg':
     case 'image/jpg':
-      return 'jpeg';
+      return 'jpg';
     case 'image/png':
       return 'png';
     case 'image/gif':
@@ -16,8 +16,8 @@ function determineFileExtensionFromContentType (contentType) {
     case 'video/mp4':
       return 'mp4';
     default:
-      logger.debug('setting unknown file type as file extension jpeg');
-      return 'jpeg';
+      logger.debug('setting unknown file type as file extension jpg');
+      return 'jpg';
   }
 }
 


### PR DESCRIPTION
`image/jpg` was not a valid mime type; and we should favor `*.jpg` as used by common convention.