### PR TITLE
Add more Social Share links Addressing issue #608

### DIFF
--- a/client/scss/all.scss
+++ b/client/scss/all.scss
@@ -35,6 +35,7 @@
 @import '~row/_row';
 @import '~vertical-split/_vertical-split';
 @import '~tooltip/_tooltip';
+@import '~social-share-link/_social-share-link';
 
 @import '~channel-claims-display/_channel-claims-display';
 @import '~dropzone/_dropzone';

--- a/client/scss/social-share-link/_social-share-link.scss
+++ b/client/scss/social-share-link/_social-share-link.scss
@@ -7,4 +7,5 @@
 .social-share-link > a{
   padding-right:0.5em;
   padding-left:0.5em;
+  padding-bottom:0.3em;
 }

--- a/client/scss/social-share-link/_social-share-link.scss
+++ b/client/scss/social-share-link/_social-share-link.scss
@@ -1,0 +1,10 @@
+.social-share-link {
+  flex-wrap: wrap;
+  margin-right: -0.5em;
+  margin-left: -0.5em;
+}
+
+.social-share-link > a{
+  padding-right:0.5em;
+  padding-left:0.5em;
+}

--- a/client/src/components/AssetShareButtons/index.js
+++ b/client/src/components/AssetShareButtons/index.js
@@ -39,6 +39,13 @@ const AssetShareButtons = ({ host, name, shortId }) => {
       >
         mastodon
       </a>
+      <a
+        className='link--primary'
+        target='_blank'
+        href={`https://share.diasporafoundation.org/?title=${name}&url=${host}/${shortId}/${name}}
+      >
+        diaspora
+      </a>
     </SocialShareLink>
   );
 };

--- a/client/src/components/AssetShareButtons/index.js
+++ b/client/src/components/AssetShareButtons/index.js
@@ -32,6 +32,13 @@ const AssetShareButtons = ({ host, name, shortId }) => {
       >
         reddit
       </a>
+      <a
+        className='link--primary'
+        target='_blank'
+        href={`https://sharetomastodon.github.io/?title=${name}&url=${host}/${shortId}/${name}`}
+      >
+        mastodon
+      </a>
     </SpaceBetween>
   );
 };

--- a/client/src/components/AssetShareButtons/index.js
+++ b/client/src/components/AssetShareButtons/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import SpaceBetween from '@components/SpaceBetween';
+import SocialShareLink from '@components/SocialShareLink';
 
 const AssetShareButtons = ({ host, name, shortId }) => {
   return (
-    <SpaceBetween >
+    <SocialShareLink >
       <a
         className='link--primary'
         target='_blank'
@@ -39,7 +39,7 @@ const AssetShareButtons = ({ host, name, shortId }) => {
       >
         mastodon
       </a>
-    </SpaceBetween>
+    </SocialShareLink>
   );
 };
 

--- a/client/src/components/SocialShareLink/index.jsx
+++ b/client/src/components/SocialShareLink/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+class SocialShareLink extends React.Component {
+  render () {
+    return (
+      <div className={'space-between social-share-link'}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+export default SocialShareLink;


### PR DESCRIPTION
## Description
Addressing issue: https://github.com/lbryio/spee.ch/issues/608
Adding share to Mastodon button.

## Preview/Demo
![screen shot 2018-10-03 at 2 10 52 pm](https://user-images.githubusercontent.com/13027142/46395568-f8ab8b80-c716-11e8-95e2-e7031deec8b3.png)


I can go on by adding share to Diaspora button and more, but it will make mobile view quite crowded & ugly. Desktop view is fine tho. 
![screen shot 2018-10-03 at 2 10 36 pm](https://user-images.githubusercontent.com/13027142/46395533-ddd91700-c716-11e8-88da-b4b9e2d333f3.png)

Might require CSS Styling changes, which I'm not currently familiar with this project CSS.

Share to Diaspora btn:
```
      <a
        className='link--primary'
        target='_blank'
        href={`https://share.diasporafoundation.org/?title=${name}&url=${host}/${shortId}/${name}`}
      >
        diaspora
      </a>
```