### PR TITLE
add share link to pleroma & friendica

### DIFF
--- a/client/src/components/AssetShareButtons/index.js
+++ b/client/src/components/AssetShareButtons/index.js
@@ -46,6 +46,20 @@ const AssetShareButtons = ({ host, name, shortId }) => {
       >
         diaspora
       </a>
+      <a
+        className='link--primary'
+        target='_blank'
+        href={`http://sharetomastodon.github.io/?title=${name}&url=${host}/${shortId}/${name}`}
+      >
+        pleroma
+      </a>
+      <a
+        className='link--primary'
+        target='_blank'
+        href={`http://sharetodiaspora.github.io/?title=${name}&url=${host}/${shortId}/${name}`}
+      >
+        friendica
+      </a>
     </SocialShareLink>
   );
 };


### PR DESCRIPTION
# Description
Continuing PR https://github.com/lbryio/spee.ch/pull/617

Adding more share link to:
- pleroma (pleroma technically use the same share button as mastodon. [reference](https://git.pleroma.social/pleroma/pleroma/issues/135))
- friendica (friendica technically use the same share button as diaspora. [reference](https://github.com/friendica/friendica/pull/1315))