### PR TITLE
Osprey landing page and styling

### DIFF
--- a/client/scss/asset-preview/_asset-preview.scss
+++ b/client/scss/asset-preview/_asset-preview.scss
@@ -1,16 +1,16 @@
 .asset-preview-image {
   width  : 100%;
-  padding: 0px;
-  margin : 0px
+  padding: 0;
+  margin : 0;
 }
 
 .asset-preview-video {
   cursor: pointer;
   background-color: #ffffff;
-  width: calc(100% - 12px - 12px - 2px);
+  width: 100%;
 }
 
-h3.list-title {
+h6.list-title {
   margin: 0;
   text-overflow: ellipsis;
   word-wrap: break-word;

--- a/client/scss/asset-preview/_asset-preview.scss
+++ b/client/scss/asset-preview/_asset-preview.scss
@@ -10,7 +10,7 @@
   width: 100%;
 }
 
-h6.list-title {
+h3.list-title {
   margin: 0;
   text-overflow: ellipsis;
   word-wrap: break-word;

--- a/client/scss/asset-preview/_asset-preview.scss
+++ b/client/scss/asset-preview/_asset-preview.scss
@@ -10,7 +10,7 @@
   width: calc(100% - 12px - 12px - 2px);
 }
 
-h6.list-title {
+h3.list-title {
   margin: 0;
   text-overflow: ellipsis;
   word-wrap: break-word;

--- a/client/scss/asset-preview/_asset-preview.scss
+++ b/client/scss/asset-preview/_asset-preview.scss
@@ -9,3 +9,12 @@
   background-color: #ffffff;
   width: calc(100% - 12px - 12px - 2px);
 }
+
+h6.list-title {
+  margin: 0;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow: hidden;
+  line-height: 1em;
+  max-height: 2em;
+}

--- a/client/scss/channel-claims-display/_channel-claims-display.scss
+++ b/client/scss/channel-claims-display/_channel-claims-display.scss
@@ -1,5 +1,26 @@
 .channel-claims-display {
+  display: grid;
+  grid-gap: 16px;
+
   .button--secondary {
     margin-right: $secondary-padding;
+  }
+}
+
+@media (min-width: 1040px) {
+  .channel-claims-display {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1039px) {
+  .channel-claims-display {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 767px) {
+  .channel-claims-display {
+    grid-template-columns: 1fr;
   }
 }

--- a/client/scss/channel-claims-display/_channel-claims-display.scss
+++ b/client/scss/channel-claims-display/_channel-claims-display.scss
@@ -1,10 +1,7 @@
 .channel-claims-display {
+  width: 100%;
   display: grid;
   grid-gap: 16px;
-
-  .button--secondary {
-    margin-right: $secondary-padding;
-  }
 }
 
 @media (min-width: 1040px) {

--- a/client/src/components/AssetPreview/index.jsx
+++ b/client/src/components/AssetPreview/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, contentType, thumbnail } }) => {
+const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, contentType, thumbnail, title } }) => {
   const embedUrl = `/${claimId}/${name}.${fileExt}`;
   const showUrl = `/${claimId}/${name}`;
   return (
@@ -13,19 +13,25 @@ const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, c
           case 'image/png':
           case 'image/gif':
             return (
-              <img
-                className={'asset-preview-image'}
-                src={embedUrl}
-                alt={name}
-              />
+              <div>
+                <h6 class='list-title'>{title}</h6>
+                <img
+                  className={'asset-preview-image'}
+                  src={embedUrl}
+                  alt={name}
+                />
+              </div>
             );
           case 'video/mp4':
             return (
-              <img
-                className={'asset-preview-video'}
-                src={thumbnail || defaultThumbnail}
-                alt={name}
-              />
+              <div>
+                <h6 class='list-title'>{title}</h6>
+                <img
+                  className={'asset-preview-video'}
+                  src={thumbnail || defaultThumbnail}
+                  alt={name}
+                />
+              </div>
             );
           default:
             return (

--- a/client/src/components/AssetPreview/index.jsx
+++ b/client/src/components/AssetPreview/index.jsx
@@ -5,7 +5,7 @@ const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, c
   const embedUrl = `/${claimId}/${name}.${fileExt}`;
   const showUrl = `/${claimId}/${name}`;
   return (
-    <Link to={showUrl} >
+    <Link to={showUrl} className='asset-preview'>
       {(() => {
         switch (contentType) {
           case 'image/jpeg':

--- a/client/src/components/AssetPreview/index.jsx
+++ b/client/src/components/AssetPreview/index.jsx
@@ -14,23 +14,23 @@ const AssetPreview = ({ defaultThumbnail, claimData: { name, claimId, fileExt, c
           case 'image/gif':
             return (
               <div>
-                <h6 class='list-title'>{title}</h6>
                 <img
                   className={'asset-preview-image'}
                   src={embedUrl}
                   alt={name}
                 />
+                <h3 className='list-title'>{title}</h3>
               </div>
             );
           case 'video/mp4':
             return (
               <div>
-                <h6 class='list-title'>{title}</h6>
                 <img
                   className={'asset-preview-video'}
                   src={thumbnail || defaultThumbnail}
                   alt={name}
                 />
+                <h3 className='list-title'>{title}</h3>
               </div>
             );
           default:

--- a/client/src/containers/ChannelClaimsDisplay/view.jsx
+++ b/client/src/containers/ChannelClaimsDisplay/view.jsx
@@ -29,14 +29,18 @@ class ChannelClaimsDisplay extends React.Component {
     const {channel: {claimsData: {claims, currentPage, totalPages}}, defaultThumbnail} = this.props;
     if (claims.length > 0) {
       return (
-        <div className={'channel-claims-display'}>
-          {claims.map(claim => (
-            <AssetPreview
-              defaultThumbnail={defaultThumbnail}
-              claimData={claim}
-              key={`${claim.name}-${claim.id}`}
-            />
-          ))}
+        <div>
+          <div>
+            <div className={'channel-claims-display'}>
+              {claims.map(claim => (
+                <AssetPreview
+                  defaultThumbnail={defaultThumbnail}
+                  claimData={claim}
+                  key={`${claim.name}-${claim.id}`}
+                />
+              ))}
+            </div>
+          </div>
           <Row>
             {(currentPage > 1) &&
             <ButtonSecondary

--- a/client/src/containers/ChannelClaimsDisplay/view.jsx
+++ b/client/src/containers/ChannelClaimsDisplay/view.jsx
@@ -27,59 +27,16 @@ class ChannelClaimsDisplay extends React.Component {
   }
   render () {
     const {channel: {claimsData: {claims, currentPage, totalPages}}, defaultThumbnail} = this.props;
-    const groupedClaimsList = createGroupedList(claims, 4);
     if (claims.length > 0) {
       return (
         <div className={'channel-claims-display'}>
-          <div>
-            {groupedClaimsList.map((group, index) => {
-              const itemA = group[0];
-              const itemB = group[1];
-              const itemC = group[2];
-              const itemD = group[3];
-              return (
-                <HorizontalQuadSplit
-                  key={`claims-row-${index}`}
-                  columnA={
-                    itemA && (
-                      <AssetPreview
-                        defaultThumbnail={defaultThumbnail}
-                        claimData={itemA}
-                        key={`${itemA.name}-${itemA.id}`}
-                      />
-                    )
-                  }
-                  columnB={
-                    itemB && (
-                      <AssetPreview
-                        defaultThumbnail={defaultThumbnail}
-                        claimData={itemB}
-                        key={`${itemB.name}-${itemB.id}`}
-                      />
-                    )
-                  }
-                  columnC={
-                    itemC && (
-                      <AssetPreview
-                        defaultThumbnail={defaultThumbnail}
-                        claimData={itemC}
-                        key={`${itemC.name}-${itemC.id}`}
-                      />
-                    )
-                  }
-                  columnD={
-                    itemD && (
-                      <AssetPreview
-                        defaultThumbnail={defaultThumbnail}
-                        claimData={itemD}
-                        key={`${itemD.name}-${itemD.id}`}
-                      />
-                    )
-                  }
-                />
-              );
-            })}
-          </div>
+          {claims.map(claim => (
+            <AssetPreview
+              defaultThumbnail={defaultThumbnail}
+              claimData={claim}
+              key={`${claim.name}-${claim.id}`}
+            />
+          ))}
           <Row>
             {(currentPage > 1) &&
             <ButtonSecondary

--- a/client/src/pages/ShowChannel/index.js
+++ b/client/src/pages/ShowChannel/index.js
@@ -1,19 +1,20 @@
 import { connect } from 'react-redux';
 import View from './view';
 
-const mapStateToProps = ({ show }) => {
+const mapStateToProps = ({ show, site, channel }) => {
   // select request info
   const requestId = show.request.id;
   // select request
   const previousRequest = show.requestList[requestId] || null;
   // select channel
-  let channel;
+  let thisChannel;
   if (previousRequest) {
     const channelKey = previousRequest.key;
-    channel = show.channelList[channelKey] || null;
+    thisChannel = show.channelList[channelKey] || null;
   }
   return {
-    channel,
+    channel    : thisChannel,
+    homeChannel: site.publishOnlyApproved && !channel.loggedInChannel.name ? `${site.approvedChannels[0].name}:${site.approvedChannels[0].longId}` : null,
   };
 };
 

--- a/client/src/pages/ShowChannel/view.jsx
+++ b/client/src/pages/ShowChannel/view.jsx
@@ -7,7 +7,7 @@ import Row from '@components/Row';
 
 class ShowChannel extends React.Component {
   render () {
-    const { channel } = this.props;
+    const { channel, homeChannel } = this.props;
     if (channel) {
       const { name, longId, shortId } = channel;
       return (
@@ -15,13 +15,15 @@ class ShowChannel extends React.Component {
           pageTitle={name}
           channel={channel}
         >
-          <Row>
-            <ChannelInfoDisplay
-              name={name}
-              longId={longId}
-              shortId={shortId}
-            />
-          </Row>
+          {!homeChannel && (
+            <Row>
+              <ChannelInfoDisplay
+                name={name}
+                longId={longId}
+                shortId={shortId}
+              />
+            </Row>
+          )}
           <ChannelClaimsDisplay />
         </PageLayout>
       );

--- a/client/src/pages/ShowChannel/view.jsx
+++ b/client/src/pages/ShowChannel/view.jsx
@@ -24,7 +24,9 @@ class ShowChannel extends React.Component {
               />
             </Row>
           )}
-          <ChannelClaimsDisplay />
+          <Row>
+            <ChannelClaimsDisplay />
+          </Row>
         </PageLayout>
       );
     }


### PR DESCRIPTION
#603 

- remove channel info for multisite instances
- remove "grouping" of claims
- use grid for channel asset list display
- add title below thumbnail