### PR TITLE
fix "longChannelId does not exist"

### DIFF
--- a/server/controllers/utils/getClaimId.js
+++ b/server/controllers/utils/getClaimId.js
@@ -15,7 +15,7 @@ const getClaimIdByChannel = async (channelName, channelClaimId, claimName) => {
   let claimId = await chainquery.claim.queries.getClaimIdByLongChannelId(channelId, claimName);
 
   if(claimId === null) {
-    claimId = db.Claim.getClaimIdByLongChannelId(longChannelId, claimName);
+    claimId = db.Claim.getClaimIdByLongChannelId(channelId, claimName);
   }
 
   return claimId;


### PR DESCRIPTION
I forget exactly when/how the error came up but it was "longChannelId does not exist"

I looked at the code and found a non-existent variable used as an argument

it maybe should have been `channelClaimId` but this made more sense

