### PR TITLE
refactor getClaimIdAndServeAsset using async/await

### DIFF
--- a/server/controllers/assets/utils/getClaimIdAndServeAsset.js
+++ b/server/controllers/assets/utils/getClaimIdAndServeAsset.js
@@ -17,81 +17,63 @@ const CONTENT_UNAVAILABLE = 'CONTENT_UNAVAILABLE';
 
 const { publishing: { serveOnlyApproved, approvedChannels } } = require('@config/siteConfig');
 
-const getClaimIdAndServeAsset = (channelName, channelClaimId, claimName, claimId, originalUrl, ip, res) => {
-  getClaimId(channelName, channelClaimId, claimName, claimId)
-    .then(fullClaimId => {
-      claimId = fullClaimId;
-      return chainquery.claim.queries.resolveClaim(claimName, fullClaimId).catch(() => {});
-    })
-    .then(claim => {
-      if (!claim) {
-        logger.debug('Full claim id:', claimId);
-        return db.Claim.findOne({
-          where: {
-            name   : claimName,
-            claimId,
-          },
-        });
-      }
+const getClaimIdAndServeAsset = async (channelName, channelClaimId, name, _claimId, originalUrl, ip, res) => {
+  try {
+    const claimId = await getClaimId(channelName, channelClaimId, name, _claimId);
 
-      return claim;
-    })
-    .then(claim => {
-      if (serveOnlyApproved && !isApprovedChannel({ longId: claim.dataValues.publisher_id }, approvedChannels)) {
-        throw new Error(CONTENT_UNAVAILABLE);
-      }
-      logger.debug('Outpoint:', claim.dataValues.outpoint);
-      return db.Blocked.isNotBlocked(claim.dataValues.outpoint);
-    })
-    .then(() => {
-      return db.File.findOne({
-        where: {
-          claimId,
-          name: claimName,
-        },
+    let _claim;
+    _claim = await chainquery.claim.queries.resolveClaim(name, claimId);
+    if (!_claim) {
+      _claim = await db.Claim.findOne({ where: { name, claimId } });
+    }
+    const claim = _claim.dataValues;
+
+    if (serveOnlyApproved && !isApprovedChannel({ longId: claim.publisher_id }, approvedChannels)) {
+      throw new Error(CONTENT_UNAVAILABLE);
+    }
+    await db.Blocked.isNotBlocked(claim.outpoint);
+
+    const fileRecord = await db.File.findOne({ where: { name, claimId } });
+    if (!fileRecord) {
+      throw NO_FILE;
+    }
+
+    serveFile(fileRecord.dataValues, res);
+  } catch (error) {
+    if (error === NO_CLAIM) {
+      logger.debug('no claim found');
+      return res.status(404).json({
+        success: false,
+        message: 'No matching claim id could be found for that url',
       });
-    })
-    .then(fileRecord => {
-      if (!fileRecord) {
-        throw NO_FILE;
-      }
-      serveFile(fileRecord.dataValues, res);
-    })
-    .catch(error => {
-      if (error === NO_CLAIM) {
-        logger.debug('no claim found');
-        return res.status(404).json({
-          success: false,
-          message: 'No matching claim id could be found for that url',
-        });
-      }
-      if (error === NO_CHANNEL) {
-        logger.debug('no channel found');
-        return res.status(404).json({
-          success: false,
-          message: 'No matching channel id could be found for that url',
-        });
-      }
-      if (error === CONTENT_UNAVAILABLE) {
-        logger.debug('unapproved channel');
-        return res.status(400).json({
-          success: false,
-          message: 'This content is unavailable',
-        });
-      }
-      if (error === BLOCKED_CLAIM) {
-        logger.debug('claim was blocked');
-        return res.status(451).json({
-          success: false,
-          message: 'In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications. For more details, see https://lbry.io/faq/dmca',
-        });
-      }
-      if (error === NO_FILE) {
-        logger.debug('no file available');
-        return res.status(307).redirect(`/api/claim/get/${claimName}/${claimId}`);
-      }
-      handleErrorResponse(originalUrl, ip, error, res);
-    });
+    }
+    if (error === NO_CHANNEL) {
+      logger.debug('no channel found');
+      return res.status(404).json({
+        success: false,
+        message: 'No matching channel id could be found for that url',
+      });
+    }
+    if (error === CONTENT_UNAVAILABLE) {
+      logger.debug('unapproved channel');
+      return res.status(400).json({
+        success: false,
+        message: 'This content is unavailable',
+      });
+    }
+    if (error === BLOCKED_CLAIM) {
+      logger.debug('claim was blocked');
+      return res.status(451).json({
+        success: false,
+        message: 'In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications. For more details, see https://lbry.io/faq/dmca',
+      });
+    }
+    if (error === NO_FILE) {
+      logger.debug('no file available');
+      return res.status(307).redirect(`/api/claim/get/${claimName}/${claimId}`);
+    }
+    handleErrorResponse(originalUrl, ip, error, res);
+  }
 };
 
 module.exports = getClaimIdAndServeAsset;


### PR DESCRIPTION
I refactored this function using async/await to debug multisite content blocking. That princess is in another castle but this is a step towards a cleaner code base.