### PR TITLE
Allow external channels to load via chainquery

### DIFF
--- a/server/controllers/api/channel/data/getChannelData.js
+++ b/server/controllers/api/channel/data/getChannelData.js
@@ -1,28 +1,25 @@
-const db = require('../../../../models');
+const db = require('server/models');
+const chainquery = require('chainquery');
 
-const getChannelData = (channelName, channelClaimId) => {
-  return new Promise((resolve, reject) => {
-    let longChannelClaimId;
-    // 1. get the long channel Id (make sure channel exists)
-    db.Certificate
-      .getLongChannelId(channelName, channelClaimId)
-      .then(fullClaimId => {
-        longChannelClaimId = fullClaimId;
-        return db
-          .Certificate
-          .getShortChannelIdFromLongChannelId(fullClaimId, channelName);
-      })
-      .then(shortChannelClaimId => {
-        resolve({
-          channelName,
-          longChannelClaimId,
-          shortChannelClaimId,
-        });
-      })
-      .catch(error => {
-        reject(error);
-      });
-  });
+const getChannelData = async (channelName, channelClaimId) => {
+  let longChannelClaimId = await chainquery.claim.queries.getLongClaimId(channelName, channelClaimId).catch(() => false);
+
+  if(!longChannelClaimId) {
+    // Allow an error to throw here if this fails
+    longChannelClaimId = await db.Certificate.getLongChannelId(channelName, channelClaimId);
+  }
+
+  let shortChannelClaimId = await chainquery.claim.queries.getShortClaimIdFromLongClaimId(longChannelClaimId, channelName).catch(() => false);
+
+  if(!shortChannelClaimId) {
+    shortChannelClaimId = await db.Certificate.getShortChannelIdFromLongChannelId(longChannelClaimId, channelName);
+  }
+
+  return {
+    channelName,
+    longChannelClaimId,
+    shortChannelClaimId,
+  };
 };
 
 module.exports = getChannelData;

--- a/server/controllers/api/channel/shortId/index.js
+++ b/server/controllers/api/channel/shortId/index.js
@@ -1,5 +1,6 @@
-const { handleErrorResponse } = require('../../../utils/errorHandlers.js');
-const db = require('../../../../models');
+const { handleErrorResponse } = require('server/controllers/utils/errorHandlers.js');
+const db = require('server/models');
+const chainquery = require('chainquery');
 
 /*
 
@@ -7,14 +8,18 @@ route to get a short channel id from long channel Id
 
 */
 
-const channelShortIdRoute = ({ ip, originalUrl, params }, res) => {
-  db.Certificate.getShortChannelIdFromLongChannelId(params.longId, params.name)
-    .then(shortId => {
-      res.status(200).json(shortId);
-    })
-    .catch(error => {
-      handleErrorResponse(originalUrl, ip, error, res);
-    });
+const channelShortIdRoute = async ({ ip, originalUrl, params }, res) => {
+  try {
+    let shortId = await chainquery.claim.queries.getShortClaimIdFromLongClaimId(params.longId, params.name).catch(() => false);
+
+    if(!shortId) {
+      shortId = await db.Certificate.getShortChannelIdFromLongChannelId(params.longId, params.name);
+    }
+
+    res.status(200).json(shortId);
+  } catch (error) {
+    handleErrorResponse(originalUrl, ip, error, res);
+  }
 };
 
 module.exports = channelShortIdRoute;

--- a/server/controllers/api/claim/longId/index.js
+++ b/server/controllers/api/claim/longId/index.js
@@ -1,9 +1,9 @@
-const db = require('../../../../models');
+const db = require('server/models');
 const chainquery = require('chainquery');
 
-const { handleErrorResponse } = require('../../../utils/errorHandlers.js');
+const { handleErrorResponse } = require('server/controllers/utils/errorHandlers.js');
 
-const getClaimId = require('../../../utils/getClaimId.js');
+const getClaimId = require('server/controllers/utils/getClaimId.js');
 
 const NO_CHANNEL = 'NO_CHANNEL';
 const NO_CLAIM = 'NO_CLAIM';

--- a/server/controllers/utils/getClaimId.js
+++ b/server/controllers/utils/getClaimId.js
@@ -6,7 +6,7 @@ const chainquery = require('chainquery');
 const getClaimIdByChannel = async (channelName, channelClaimId, claimName) => {
   logger.debug(`getClaimIdByChannel(${channelName}, ${channelClaimId}, ${claimName})`);
 
-  let channelId = await chainquery.claim.queries.getLongClaimIdFromShortClaimId(channelName, channelClaimId);
+  let channelId = await chainquery.claim.queries.getLongClaimId(channelName, channelClaimId);
 
   if(channelId === null) {
     channelId = await db.Certificate.getLongChannelId(channelName, channelClaimId);


### PR DESCRIPTION
~~WIP, this is usable as-is, one known edge case does not work -> `/@channelName/claimName`~~

~~Channels load with and without ID's, claim pages require a channel ID present.~~

Should be working in full