### PR TITLE
Make configurable embeds

### DIFF
--- a/client/src/containers/AssetInfo/view.jsx
+++ b/client/src/containers/AssetInfo/view.jsx
@@ -90,7 +90,7 @@ class AssetInfo extends React.Component {
                 {(contentType === 'video/mp4') ? (
                   <ClickToCopy
                     id={'embed-text-video'}
-                    value={`<iframe src="${host}/${claimId}/${name}.${fileExt}" allowfullscreen="true" style="border:0" /></iframe>`}
+                    value={`<iframe src="${host}/video-embed/${name}/${claimId}" allowfullscreen="true" style="border:0" /></iframe>`}
                   />
                 ) : (
                   <ClickToCopy

--- a/client/src/containers/AssetInfo/view.jsx
+++ b/client/src/containers/AssetInfo/view.jsx
@@ -90,7 +90,7 @@ class AssetInfo extends React.Component {
                 {(contentType === 'video/mp4') ? (
                   <ClickToCopy
                     id={'embed-text-video'}
-                    value={`<video width="100%" controls poster="${thumbnail}" src="${host}/${claimId}/${name}.${fileExt}"/></video>`}
+                    value={`<iframe src="${host}/${claimId}/${name}.${fileExt}" allowfullscreen="true" style="border:0" /></iframe>`}
                   />
                 ) : (
                   <ClickToCopy

--- a/server/controllers/pages/sendVideoEmbedPage.js
+++ b/server/controllers/pages/sendVideoEmbedPage.js
@@ -1,13 +1,87 @@
-const { details: { host } } = require('@config/siteConfig');
+const {
+  assetDefaults: { thumbnail },
+  details: { host },
+} = require('@config/siteConfig');
 
-const sendVideoEmbedPage = ({ params }, res) => {
-  const claimId = params.claimId;
-  const name = params.name;
+const padSizes = {
+  small: 'padSmall',
+  medium: 'padMedium',
+  large: 'padLarge',
+};
+
+const argumentProcessors = {
+  'bottom': async (config) => {
+    config.classNames.push('bottom');
+    return;
+  },
+  'right': async (config) => {
+    config.classNames.push('right');
+    return;
+  },
+  'pad': async (config, val) => {
+    config.classNames.push(padSizes[val]);
+    return;
+  },
+  'logoClaim': async (config, val) => {
+    config.logoUrl = `${host}/${val}`;
+    return;
+  },
+  'link': async (config, val) => {
+    config.logoLink = val;
+    return;
+  }
+};
+
+const parseLogoConfigParam = async (rawConfig) => {
+  if(rawConfig) {
+    let parsedConfig = {
+      classNames: ['logoLink'],
+      logoUrl: thumbnail,
+    };
+    let splitConfig;
+    try {
+      splitConfig = rawConfig.split(',');
+    } catch(e) { }
+
+    if(!splitConfig) {
+      return false;
+    }
+
+    for(let i = 0; i < splitConfig.length; i++) {
+      let currentArgument = splitConfig[i];
+
+      if(argumentProcessors[currentArgument]) {
+        await argumentProcessors[currentArgument](parsedConfig);
+      } else {
+        const splitArgument = currentArgument.split(':');
+        if(argumentProcessors[splitArgument[0]]) {
+          await argumentProcessors[splitArgument[0]](parsedConfig, splitArgument[1]);
+        }
+      }
+    }
+
+    parsedConfig.classNames = parsedConfig.classNames.join(' ');
+
+    return parsedConfig;
+  }
+
+  return false;
+}
+
+const sendVideoEmbedPage = async ({ params }, res) => {
+  const {
+    claimId,
+    config,
+    name,
+  } = params;
+
+  const logoConfig = await parseLogoConfigParam(config);
+
   // test setting response headers
   console.log('removing x-frame-options');
   res.removeHeader('X-Frame-Options');
   // get and render the content
-  res.status(200).render('embed', { host, claimId, name });
+  res.status(200).render('embed', { host, claimId, name, logoConfig });
 };
 
 module.exports = sendVideoEmbedPage;

--- a/server/routes/pages/index.js
+++ b/server/routes/pages/index.js
@@ -16,5 +16,5 @@ module.exports = {
   '/popular': { controller: handlePageRequest },
   '/new': { controller: handlePageRequest },
   '/multisite': { controller: handlePageRequest },
-  '/video-embed/:name/:claimId': { controller: handleVideoEmbedRequest },  // for twitter
+  '/video-embed/:name/:claimId/:config?': { controller: handleVideoEmbedRequest },  // for twitter
 };

--- a/server/views/embed.handlebars
+++ b/server/views/embed.handlebars
@@ -1,4 +1,7 @@
-<video controls>
+<div class="container">
+  {{> logo}}
+  <video controls>
     <source src="{{host}}/{{claimId}}/{{name}}.mp4" type="video/mp4">
     Your browser does not support video
-</video>
+  </video>
+</div>

--- a/server/views/layouts/embed.handlebars
+++ b/server/views/layouts/embed.handlebars
@@ -3,7 +3,8 @@
 <head>
   <style type="text/css">
   body {
-    margin:0;
+    margin: 0;
+    overflow: hidden;
   }
 
   .container {

--- a/server/views/layouts/embed.handlebars
+++ b/server/views/layouts/embed.handlebars
@@ -1,16 +1,40 @@
 <!DOCTYPE html>
 <html>
+<head>
+  <style type="text/css">
+  body {
+    margin:0;
+  }
+
+  .container {
+    height: 100vh;
+  }
+
+  video {
+    width: 100%;
+    height: 100%;
+  }
+
+  .logoLink {
+    margin-bottom: 80px; /* don't cover controls */
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+  }
+
+  .logo {
+    max-height: 128px;
+    max-width: 64px;
+  }
+
+  .bottom { bottom: 0 }
+  .right { right: 0 }
+  .padSmall { padding: 10px }
+  .padMedium { padding: 20px }
+  .padLarge { padding: 30px }
+  </style>
+</head>
 <body>
-
-<style type="text/css">
-    video {
-        width:100%;
-        max-width:600px;
-        height:auto;
-    }
-</style>
-
-{{{ body }}}
-
+  {{{ body }}}
 </body>
 </html>

--- a/server/views/partials/logo.handlebars
+++ b/server/views/partials/logo.handlebars
@@ -1,0 +1,5 @@
+{{#if logoConfig}}
+  <a class="{{logoConfig.classNames}}" href="{{#if logoConfig.logoLink}}{{logoConfig.logoLink}}{{else}}{{host}}/{{claimId}}/{{name}}{{/if}}">
+    <img class="logo" src="{{logoConfig.logoUrl}}" />
+  </a>
+{{/if}}


### PR DESCRIPTION
Works and is usable and ready to merge, still working on final touches.

e.g.:
```
http://localhost:3000/video-embed/jiggytom/3023ed665a45361626f70375db616af074f314ab/pad:large,bottom,logoClaim:252e3c5137c076d4ea0786c0d418e965b5c1e9cf%2Fantimedia-logo
```

Supports:

- pad:{[small, medium, large]}
- bottom
- right
- logoClaim:{claimId}%2F{claimName}
- logoLink:{url}

Also has some player fixes to properly adjust sizing.  This should provide a much better embed experience.