### PR TITLE
fixes missing amount at configure

### DIFF
--- a/cli/configure.js
+++ b/cli/configure.js
@@ -39,10 +39,10 @@ const {
     port,
     title,
     host,
-    channelClaimBidAmount: channelBid,
   },
   publishing: {
     uploadDirectory,
+    channelClaimBidAmount: channelBid,
   },
 } = siteConfig;
 


### PR DESCRIPTION
configure.js was destructuring channelClaimBidAmount incorrectly from the siteConfig. It is now moved to the proper place.  