### PR TITLE
move pages to last in route order

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,7 @@
 module.exports = {
-  ...require('./pages'),
   ...require('./api'),
   ...require('./auth'),
   ...require('./assets'),
   ...require('./fallback'),
+  ...require('./pages'),
 };


### PR DESCRIPTION
when visiting a page such as new or login at `spee.ch/${pageName}` it will treat the `pageName` as a claim and serve that; this PR fixes this problem

I don't know exactly why/how but it has something to do with object property ordering when the routes are imported from their respective files and put together with object spread