### PR TITLE
return null if either requestId or requestType are undefined

### DIFF
--- a/server/render/build/handleShowRender.js
+++ b/server/render/build/handleShowRender.js
@@ -44,6 +44,10 @@ var getCanonicalUrlFromShow = function getCanonicalUrlFromShow(show) {
   var requestId = show.requestList[show.request.id];
   var requestType = show.request.type;
 
+  if (!requestId || !requestType) {
+    return null;
+  }
+
   switch (requestType) {
     case 'ASSET_DETAILS':
       var asset = show.assetList[requestId.key];

--- a/server/render/src/handleShowRender.jsx
+++ b/server/render/src/handleShowRender.jsx
@@ -20,6 +20,9 @@ const createCanonicalLink = require('../../../utils/createCanonicalLink');
 const getCanonicalUrlFromShow = show => {
   const requestId = show.requestList[show.request.id];
   const requestType = show.request.type;
+  if (!requestId || !requestType) {
+    return null;
+  }
   switch (requestType) {
     case 'ASSET_DETAILS':
       const asset = show.assetList[requestId.key];

--- a/server/render/src/handleShowRender.jsx
+++ b/server/render/src/handleShowRender.jsx
@@ -20,9 +20,11 @@ const createCanonicalLink = require('../../../utils/createCanonicalLink');
 const getCanonicalUrlFromShow = show => {
   const requestId = show.requestList[show.request.id];
   const requestType = show.request.type;
+  
   if (!requestId || !requestType) {
     return null;
   }
+  
   switch (requestType) {
     case 'ASSET_DETAILS':
       const asset = show.assetList[requestId.key];
@@ -39,6 +41,7 @@ const returnSagaWithParams = (saga, params) => {
     yield call(saga, params);
   };
 };
+
 module.exports = (req, res) => {
   let context = {};
 
@@ -54,6 +57,7 @@ module.exports = (req, res) => {
     // Workaround, remove when a solution for async httpContext exists
     const showState = store.getState().show;
     const assetKeys = Object.keys(showState.assetList);
+    
     if(assetKeys.length !== 0) {
       res.claimId = showState.assetList[assetKeys[0]].claimId;
     } else {


### PR DESCRIPTION
Canonical URL forwarding throws an error when the saga does not put the asset data in the store

`TypeError: Cannot read property 'key' of undefined`

