### PR TITLE
fixes blank tiles due to unsupported content

### DIFF
--- a/server/chainquery/bundle.js
+++ b/server/chainquery/bundle.js
@@ -869,15 +869,35 @@ var claimQueries = (db, table, sequelize) => ({
     });
   },
 
-  getAllChannelClaims: async (channelClaimId, bidState) => {
+  getAllChannelClaims: async (channelClaimId, params) => {
     logger$1.debug(`claim.getAllChannelClaims for ${channelClaimId}`);
-    const whereClause = bidState || {
-      [sequelize.Op.or]: [
-        { bid_state: 'Controlling' },
-        { bid_state: 'Active' },
-        { bid_state: 'Accepted' },
-      ],
+
+    const defaultWhereClauses = {
+      bid_state:
+      { [sequelize.Op.or]: ['Controlling', 'Active', 'Accepted'] }
     };
+
+    const addWhereClauses = (whereClauses, params) => {
+      /*
+       input params = { col: ['Val', 'Val']}
+       output = { col: { Op.or : [ { Op.eq: 'Value'},...]}, col2:...}
+      */
+      const cols = Object.keys(params);
+      for (let colKey in cols){
+        let col = Object.keys(params)[colKey];
+
+        whereClauses[col] = {};
+        whereClauses[col][sequelize.Op.or] = [];
+        for (let itemKey in params[col] ){
+          let itemsArr = params[col];
+          whereClauses[col][sequelize.Op.or].push({ [sequelize.Op.eq]: itemsArr[itemKey] });
+        }
+      }
+      return whereClauses;
+    };
+
+    const whereClause = addWhereClauses(defaultWhereClauses, params);
+
     const selectWhere = {
       ...whereClause,
       publisher_id: channelClaimId,

--- a/server/controllers/api/channel/claims/getChannelClaims.js
+++ b/server/controllers/api/channel/claims/getChannelClaims.js
@@ -5,10 +5,16 @@ const { returnPaginatedChannelClaims } = require('./channelPagination.js');
 
 const getChannelClaims = async (channelName, channelShortId, page) => {
   const channelId = await chainquery.claim.queries.getLongClaimId(channelName, channelShortId);
-
+  const params = { content_type: [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/gif',
+    'video/mp4',
+  ] };
   let channelClaims;
   if (channelId) {
-    channelClaims = await chainquery.claim.queries.getAllChannelClaims(channelId);
+    channelClaims = await chainquery.claim.queries.getAllChannelClaims(channelId, params);
   }
 
   const processingChannelClaims = channelClaims ? channelClaims.map((claim) => getClaimData(claim)) : [];


### PR DESCRIPTION
This is a draft of a solution. 

1) What I'd like to do is have a central list of supported type strings ( 'image/jpg' ); passing this list allows for future filtering. Would it be better for supported types be passed or require()d?

2) Also, this function could be renamed or duplicated to GetAllMatchingChannelClaims, GetAllSupportedChannelClaims, or just GetChannelClaims. I don't think it makes sense to duplicate it just to get at currently unsupported content.