### PR TITLE
standardizes channelClaimsArray order to match lbryumx sorting

### DIFF
--- a/server/chainquery/bundle.js
+++ b/server/chainquery/bundle.js
@@ -904,7 +904,7 @@ var claimQueries = (db, table, sequelize) => ({
     };
     return await table.findAll({
       where: selectWhere,
-      order: [['height', 'DESC']],
+      order: [['height', 'DESC'],['claim_id', 'ASC']],
     })
       .then(channelClaimsArray => {
         if (channelClaimsArray.length === 0) {

--- a/server/chainquery/queries/claimQueries.js
+++ b/server/chainquery/queries/claimQueries.js
@@ -103,7 +103,7 @@ export default (db, table, sequelize) => ({
     };
     return await table.findAll({
       where: selectWhere,
-      order: [['height', 'DESC']],
+      order: [['height', 'DESC'],['claim_id', 'ASC']],
     })
       .then(channelClaimsArray => {
         if (channelClaimsArray.length === 0) {


### PR DESCRIPTION
Previous behavior:
Speech displayed results sorted only by height.
New behavior:
Speech displays results sorted by height, then claimID ascending.
Speech channel order matches lbry-desktop.

Will revisit when metadata contains date field.
