### PR TITLE
ensures that getClaimIdByLongChannelId tests for bidstate

### DIFF
--- a/server/chainquery/bundle.js
+++ b/server/chainquery/bundle.js
@@ -917,7 +917,7 @@ var claimQueries = (db, table, sequelize) => ({
   getClaimIdByLongChannelId: async (channelClaimId, claimName) => {
     logger$1.debug(`finding claim id for claim ${claimName} from channel ${channelClaimId}`);
     return await table.findAll({
-      where: { name: claimName, publisher_id: channelClaimId },
+      where: { name: claimName, publisher_id: channelClaimId, bid_state: { [sequelize.Op.or]: ['Controlling', 'Active', 'Accepted'] } },
       order: [['id', 'ASC']],
     })
     .then(result => {

--- a/server/chainquery/queries/claimQueries.js
+++ b/server/chainquery/queries/claimQueries.js
@@ -116,7 +116,7 @@ export default (db, table, sequelize) => ({
   getClaimIdByLongChannelId: async (channelClaimId, claimName) => {
     logger.debug(`finding claim id for claim ${claimName} from channel ${channelClaimId}`);
     return await table.findAll({
-      where: { name: claimName, publisher_id: channelClaimId },
+      where: { name: claimName, publisher_id: channelClaimId, bid_state: { [sequelize.Op.or]: ['Controlling', 'Active', 'Accepted'] } },
       order: [['id', 'ASC']],
     })
     .then(result => {


### PR DESCRIPTION
Old behavior: Chainquery would get a list of claims taking bidstate into account, however, would get the claim using longId without taking bidstate into account. Yielded 
`warn: 2 records found for ...`
New behavior: previously mis-resolved claims no longer happen.
Not sure this fixes every related issue, but it seems obvious in hindsight.