### PR TITLE
fixes bug in lbryurl copy

### DIFF
--- a/client/src/containers/AssetInfo/view.jsx
+++ b/client/src/containers/AssetInfo/view.jsx
@@ -27,7 +27,6 @@ class AssetInfo extends React.Component {
         shortId: channelShortId,
       };
       channelCanonicalUrl = `${createCanonicalLink({channel})}`;
-      console.log(channelName)
     }
     return (
       <div className='asset-info'>

--- a/client/src/containers/AssetInfo/view.jsx
+++ b/client/src/containers/AssetInfo/view.jsx
@@ -27,6 +27,7 @@ class AssetInfo extends React.Component {
         shortId: channelShortId,
       };
       channelCanonicalUrl = `${createCanonicalLink({channel})}`;
+      console.log(channelName)
     }
     return (
       <div className='asset-info'>
@@ -120,7 +121,7 @@ class AssetInfo extends React.Component {
                 }
                 content={
                   <ClickToCopy
-                    id={'short-link'}
+                    id={'lbry-permanent-url'}
                     value={`${channelName}#${certificateId}/${name}`}
                   />
                 }


### PR DESCRIPTION
Previous fix using id='short-link' caused copy button to copy contents of another element. This copies as intended.