### PR TITLE
fixes channel claim issue introduced by file extension fix

### DIFF
--- a/server/utils/getClaimData.js
+++ b/server/utils/getClaimData.js
@@ -22,7 +22,7 @@ module.exports = async (data) => {
   let lbrynetFileExt = null;
   if (!data.fileExt) {
     lbrynetClaimResult = await getClaim(lbrynetUri).catch(() => { return 'invalid URI' });
-    lbrynetFileExt = lbrynetClaimResult && lbrynetClaimResult.file_name.split('.').slice(-1).pop();
+    lbrynetFileExt = lbrynetClaimResult && lbrynetClaimResult.file_name && lbrynetClaimResult.file_name.split('.').slice(-1).pop();
   }
 
   // TODO verify that "generated_x" does anything at all


### PR DESCRIPTION
Previous fix attempted to call split when file_name didn't exist such as on channel claims.
Code now checks for that.
Future not implemented yet: filenames without a . should have '' extension.