### PR TITLE
app sends 404 code for /fallback and failing canonical

### DIFF
--- a/server/render/handleShowRender.jsx
+++ b/server/render/handleShowRender.jsx
@@ -49,6 +49,7 @@ export default (req, res) => {
     action = false,
     saga = false,
   } = httpContext.get('routeData');
+  
   if (action === 'fallback') {
     res.status(404);
   }
@@ -117,13 +118,16 @@ export default (req, res) => {
       .then(() => {
         // redirect if request does not use canonical url
         const canonicalUrl = getCanonicalUrlFromShow(store.getState().show);
+      
         if (!canonicalUrl) {
           res.status(404);
         }
+      
         if (canonicalUrl && canonicalUrl !== req.originalUrl) {
           console.log(`redirecting ${req.originalUrl} to ${canonicalUrl}`);
           res.redirect(canonicalUrl);
         }
+      
         return renderPage(store)
       });
   } else {

--- a/server/render/handleShowRender.jsx
+++ b/server/render/handleShowRender.jsx
@@ -49,9 +49,11 @@ export default (req, res) => {
     action = false,
     saga = false,
   } = httpContext.get('routeData');
+  if (action === 'fallback') {
+    res.status(404);
+  }
 
   const runSaga = (action !== false && saga !== false);
-
   const renderPage = (store) => {
 
     // Workaround, remove when a solution for async httpContext exists
@@ -63,10 +65,10 @@ export default (req, res) => {
     } else {
       const channelKeys = Object.keys(showState.channelList);
 
-      if(channelKeys.length !== 0) {
+      if (channelKeys.length !== 0) {
         res.claimId = showState.channelList[channelKeys[0]].longId;
         res.isChannel = true;
-        }
+      }
     }
 
     // render component to a string
@@ -115,6 +117,9 @@ export default (req, res) => {
       .then(() => {
         // redirect if request does not use canonical url
         const canonicalUrl = getCanonicalUrlFromShow(store.getState().show);
+        if (!canonicalUrl) {
+          res.status(404);
+        }
         if (canonicalUrl && canonicalUrl !== req.originalUrl) {
           console.log(`redirecting ${req.originalUrl} to ${canonicalUrl}`);
           res.redirect(canonicalUrl);


### PR DESCRIPTION
Previously, the 404 page responded with 200 code. 
Now it responds with 404 code when specifically the 'fallback' action from the /fallback controller exists.
Previously, an invalid claim such as /abcd/1234 responded with 200 code. Now it responds with a 404 code when canonicalUrl fails.
The home page and other redirects are unaffected.