### PR TITLE
reduces channel loadtimes, fixes fallback fileExt

### DIFF
--- a/server/controllers/api/channel/claims/getChannelClaims.js
+++ b/server/controllers/api/channel/claims/getChannelClaims.js
@@ -23,7 +23,7 @@ const getChannelClaims = async (channelName, channelShortId, page) => {
   );
   channelClaims = split.zero.concat(split.nonzero);
 
-  const processingChannelClaims = channelClaims ? channelClaims.map((claim) => getClaimData(claim)) : [];
+  const processingChannelClaims = channelClaims ? channelClaims.map((claim) => getClaimData(claim, channelName, channelShortId)) : [];
   const processedChannelClaims = await Promise.all(processingChannelClaims);
 
   return returnPaginatedChannelClaims(channelName, channelId, processedChannelClaims, page);

--- a/server/utils/getClaimData.js
+++ b/server/utils/getClaimData.js
@@ -2,30 +2,31 @@ const { details: { host } } = require('@config/siteConfig');
 const chainquery = require('chainquery').default;
 const { getClaim } = require('server/lbrynet');
 
-module.exports = async (data) => {
+module.exports = async (data, chName = null, chShortId = null) => {
   // TODO: Refactor getching the channel name out; requires invasive changes.
   const certificateId = data.publisher_id || data.certificateId;
-  const lbrynetUri = `${data.name}#${data.claim_id}`;
-  let channelName = data.channelName;
+  let lbrynetClaimResult = null;
+  let lbrynetFileExt = null;
+  let channelShortId = chShortId;
+  let channelName = chName;
 
-  if (certificateId && !channelName) {
-    channelName = await chainquery.claim.queries.getClaimChannelName(certificateId).catch(() => {});
+  if (!chName && certificateId && !channelName) {
+    channelName = await chainquery.claim.queries.getClaimChannelName(certificateId).catch(() => {
+    });
   }
 
-  let channelShortId = null;
-  if (certificateId && channelName) {
+  if (!chShortId && certificateId && channelName) {
     channelShortId = await chainquery.claim.queries.getShortClaimIdFromLongClaimId(certificateId, channelName).catch(() => null);
   }
 
-  let lbrynetClaimResult = null;
-  let lbrynetFileExt = null;
+  if (!chName && !chShortId && !data.fileExt) {
+    const lbrynetUri = `${data.name}#${data.claim_id}`;
+    lbrynetClaimResult = await getClaim(lbrynetUri).catch(() => {
+      return 'invalid URI';
+    });
+    lbrynetFileExt = lbrynetClaimResult && lbrynetClaimResult.file_name && lbrynetClaimResult.file_name.includes('.') && lbrynetClaimResult.file_name.split('.').slice(-1).pop();
+  }
 
-  // if (!data.fileExt) {
-  //   lbrynetClaimResult = await getClaim(lbrynetUri).catch(() => { return 'invalid URI' });
-  //   lbrynetFileExt = lbrynetClaimResult && lbrynetClaimResult.file_name && lbrynetClaimResult.file_name.split('.').slice(-1).pop();
-  // }
-
-  // TODO verify that "generated_x" does anything at all
   return ({
     name       : data.name,
     title      : data.title,
@@ -37,7 +38,7 @@ module.exports = async (data) => {
     fileExt    : data.generated_extension || data.fileExt || lbrynetFileExt,
     description: data.description,
     thumbnail  : data.generated_thumbnail || data.thumbnail_url || data.thumbnail,
-    outpoint   : data.transaction_hash_id || data.outpoint,
+    outpoint   : `${data.transaction_hash_id}:${data.vout}` || data.outpoint,
     host,
     pending    : Boolean(data.height === 0),
   });


### PR DESCRIPTION
Previously, getChannelClaims would, already having a channelName and channelShortId, ask getClaimData to parse some data, and getClaimData was claling chainquery twice for channelName and channelShortId.   

Now, getClaimData has optional channelName and channelShortId params.

Loadin of minutephysics decreased from 12 seconds to under 4 seconds. Loading of FTL decreased from 25 seconds to under 5 seconds.

lbrynet get is no longer called during getChannelClaims; rather only once on loading actual content.

Please test.