### PR TITLE
makes enhancements to dmca system

### DIFF
--- a/cli/defaults/siteConfig.json
+++ b/cli/defaults/siteConfig.json
@@ -17,7 +17,8 @@
     "ipAddress": "",
     "host": "https://www.example.com",
     "description": "A decentralized hosting platform built on LBRY",
-    "twitter": false
+    "twitter": false,
+    "blockListEndpoint": "https://api.lbry.io/file/list_blocked"
   },
   "publishing": {
     "primaryClaimAddress": null,

--- a/client/scss/_asset-preview.scss
+++ b/client/scss/_asset-preview.scss
@@ -2,6 +2,16 @@
   position: relative;
 }
 
+.asset-preview__blocked {
+  box-sizing: border-box;
+  background: black;
+  color: white;
+  height: 80%;
+  padding: 5px;
+  //remove margin-bottom after mystery 5px on wrapper is gone.
+  margin-bottom: 5px;
+}
+
 .asset-preview__image {
   width  : 100%;
   padding: 0;

--- a/client/src/components/AssetPreview/index.jsx
+++ b/client/src/components/AssetPreview/index.jsx
@@ -2,51 +2,59 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import createCanonicalLink from '../../../../utils/createCanonicalLink';
 
-const ClaimPending = () => {
-  return (
-    <div className='claim-pending'>PENDING</div>
-  );
-};
-
 const AssetPreview = ({ defaultThumbnail, claimData }) => {
-  const {name, fileExt, contentType, thumbnail, title, pending} = claimData;
+  const {name, fileExt, contentType, thumbnail, title, blocked} = claimData;
   const showUrl = createCanonicalLink({asset: {...claimData}});
   const embedUrl = `${showUrl}.${fileExt}`;
-  switch (contentType) {
-    case 'image/jpeg':
-    case 'image/jpg':
-    case 'image/png':
-    case 'image/gif':
-      return (
-        <Link to={showUrl} className='asset-preview'>
-          <div>
+
+  /*
+  This blocked section shouldn't be necessary after pagination is reworked,
+  though it might be useful for channel_mine situations.
+  */
+
+  if (blocked) {
+    return (
+      <div className='asset-preview'>
+        <div className='asset-preview__blocked'>
+          <h3>Error 451</h3>
+          <p>This content is blocked for legal reasons.</p>
+        </div>
+        <h3 className='asset-preview__title'>Blocked Content</h3>
+      </div>
+    );
+  } else {
+    switch (contentType) {
+      case 'image/jpeg':
+      case 'image/jpg':
+      case 'image/png':
+      case 'image/gif':
+        return (
+          <Link to={showUrl} className='asset-preview'>
             <img
               className={'asset-preview__image'}
               src={embedUrl}
               alt={name}
             />
             <h3 className='asset-preview__title'>{title}</h3>
-          </div>
-        </Link>
-      );
-    case 'video/mp4':
-      return (
-        <Link to={showUrl} className='asset-preview'>
-          <div>
+          </Link>
+        );
+      case 'video/mp4':
+        return (
+          <Link to={showUrl} className='asset-preview'>
             <div className='asset-preview__play-wrapper'>
               <img
                 className={'asset-preview__video'}
                 src={thumbnail || defaultThumbnail}
                 alt={name}
               />
-              <div className='asset-preview__play-overlay'></div>
+              <div className='asset-preview__play-overlay' />
             </div>
             <h3 className='asset-preview__title'>{title}</h3>
-          </div>
-        </Link>
-      );
-    default:
-      return null;
+          </Link>
+        );
+      default:
+        return null;
+    }
   }
 };
 

--- a/client/src/containers/AssetBlocked/index.js
+++ b/client/src/containers/AssetBlocked/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import View from './view';
+import { selectAsset } from '../../selectors/show';
+
+const mapStateToProps = (props) => {
+  const {show} = props;
+  const asset = selectAsset(show);
+  return {
+    asset,
+  };
+};
+
+export default connect(mapStateToProps, null)(View);

--- a/client/src/containers/AssetBlocked/view.jsx
+++ b/client/src/containers/AssetBlocked/view.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import createCanonicalLink from '../../../../utils/createCanonicalLink';
+import HorizontalSplit from '@components/HorizontalSplit';
+/*
+This component shouldn't be necessary after pagination is reworked,
+though it might be useful for channel_mine situations.
+*/
+class BlockedLeft extends React.PureComponent {
+  render () {
+    return (
+      <React.Fragment>
+        <img className='asset-image' src={'https://upload.wikimedia.org/wikipedia/commons/archive/a/af/20120315000030%21OR_451.svg'} alt={'451 image'} />
+      </React.Fragment>
+    );
+  }
+}
+
+class BlockedRight extends React.PureComponent {
+  render () {
+    return (
+      <React.Fragment>
+        <p>In response to a complaint we received under the US Digital Millennium Copyright Act, we have blocked access to this content from our applications.</p>
+        <p><a href={'https://lbry.io/faq/dmca'} >Click here</a> for more information.</p>
+      </React.Fragment>
+    );
+  }
+}
+
+class AssetBlocked extends React.Component {
+  componentDidMount () {
+    /*
+    This function and fetch exists to send the browser the appropriate 451 error.
+     */
+    const { asset } = this.props;
+    const { claimData: { contentType, outpoint } } = asset;
+    let fileExt;
+    if (typeof contentType === 'string') {
+      fileExt = contentType.split('/')[1] || 'jpg';
+    }
+    const sourceUrl = `${createCanonicalLink({ asset: asset.claimData })}.${fileExt}?${outpoint}`;
+    fetch(sourceUrl)
+      .catch();
+  }
+
+  render () {
+    return (
+      <div>
+        <HorizontalSplit
+          collapseOnMobile
+          leftSide={<BlockedLeft />}
+          rightSide={<BlockedRight />}
+        />
+      </div>
+    );
+  }
+};
+
+export default AssetBlocked;

--- a/client/src/pages/ShowAssetDetails/view.jsx
+++ b/client/src/pages/ShowAssetDetails/view.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PageLayout from '@components/PageLayout';
 import * as Icon from 'react-feather';
 import AssetDisplay from '@containers/AssetDisplay';
+import AssetBlocked from '@containers/AssetBlocked';
 import AssetInfo from '@containers/AssetInfo';
 import ErrorPage from '@pages/ErrorPage';
 import AssetTitle from '@containers/AssetTitle';
@@ -29,23 +30,32 @@ class ShowAssetDetails extends React.Component {
   render () {
     const { asset } = this.props;
     if (asset) {
-      const { claimData: { name } } = asset;
-      return (
-        <PageLayout
-          pageTitle={`${name} - details`}
-          asset={asset}
-        >
-          <div className="asset-main">
-            <AssetDisplay />
-            <AssetTitle />
-            
-            <button className='collapse-button' onClick={this.collapse}>
-              {this.state.closed ? <Icon.PlusCircle className='plus-icon' /> : <Icon.MinusCircle />}
-            </button>
-          </div>
-          {!this.state.closed && <AssetInfo />}
-        </PageLayout>
-      );
+      const { claimData: { name, blocked } } = asset;
+      if (!blocked) {
+        return (
+          <PageLayout
+            pageTitle={`${name} - details`}
+            asset={asset}
+          >
+            <div className="asset-main">
+              <AssetDisplay />
+              <AssetTitle />
+              <button className='collapse-button' onClick={this.collapse}>
+                {this.state.closed ? <Icon.PlusCircle className='plus-icon' /> : <Icon.MinusCircle />}
+              </button>
+            </div>
+            {!this.state.closed && <AssetInfo />}
+          </PageLayout>
+        );
+      } else {
+        return (
+          <PageLayout>
+            <div className="asset-main">
+              <AssetBlocked />
+            </div>
+          </PageLayout>
+        );
+      }
     }
     return (
       <ErrorPage error={'loading asset data...'} />

--- a/server/utils/blockList.js
+++ b/server/utils/blockList.js
@@ -1,0 +1,26 @@
+const logger = require('winston');
+const db = require('../models');
+
+let blockList = new Set();
+
+const setupBlockList = (intervalInSeconds = 60) => {
+  const fetchList = () => {
+    return new Promise((resolve, reject) => {
+      db.Blocked.getBlockList()
+        .then((result) => {
+          blockList.clear();
+          if (result.length > 0) {
+            result.map((item) => { blockList.add(item.dataValues.outpoint) });
+            resolve();
+          } else reject();
+        })
+        .catch(e => { console.error('list was empty', e) });
+    });
+  };
+  setInterval(() => { fetchList() }, intervalInSeconds * 1000);
+  return fetchList();
+};
+module.exports = {
+  isBlocked: (outpoint) => { return blockList.has(outpoint) },
+  setupBlockList,
+};


### PR DESCRIPTION
Visiting a content page shows an AssetBlocked component.
Visiting a component page still attempts to fetch() the file in order to elicit the 451 error.
I didn't want to send a 451 on document because document generally doesn't reload during normal navigation, and the document hangs on to the status throughout browsing. (This is also an issue for the 404).
Visiting a Channel page, until we redo pagination, Blocked content shows a customized 451 channel preview.
Blocklist is now in memory in a javascript Set() though I noticed no speed gains compared to local DB.
Blocklist Endpoint is now a configurable siteConfig.json -> details -> blockListEndpoint : "" parameter.
LBRY's blocklist is still the default configuration if blockListEndpoint is missing or null.
- three states of blockListEndpoint tested:
  - api-url
  - "" empty string
  - null => defaults to api-url

Blocklist Set() updates from database every 60 seconds, in preparation for periodic database updates in the future.
Some extraneous .then()s in promise chains removed.
See slack channel for test url.