### PR TITLE
Rudimentary dropdown file errors

### DIFF
--- a/client/src/containers/Dropzone/index.js
+++ b/client/src/containers/Dropzone/index.js
@@ -5,9 +5,12 @@ import View from './view';
 import siteConfig from '@config/siteConfig.json';
 import createCanonicalLink from '@globalutils/createCanonicalLink';
 
-const { assetDefaults: { thumbnail: defaultThumbnail } } = siteConfig;
+const {
+  assetDefaults: { thumbnail: defaultThumbnail },
+} = siteConfig;
 
-const mapStateToProps = ({ show, publish: { file, thumbnail, fileError, isUpdate } }) => {
+const mapStateToProps = ({ show, publish: { file, thumbnail, error, isUpdate } }) => {
+  const fileError = error.file;
   const obj = { file, thumbnail, fileError, isUpdate };
   let asset, name, claimId, fileExt, outpoint, sourceUrl;
   if (isUpdate) {
@@ -18,7 +21,7 @@ const mapStateToProps = ({ show, publish: { file, thumbnail, fileError, isUpdate
       if (obj.fileExt === 'mp4') {
         obj.sourceUrl = claimData.thumbnail ? claimData.thumbnail : defaultThumbnail;
       } else {
-        ({fileExt, outpoint} = claimData);
+        ({ fileExt, outpoint } = claimData);
         obj.sourceUrl = `${createCanonicalLink({ asset: claimData })}.${fileExt}?${outpoint}`;
       }
     }
@@ -28,14 +31,17 @@ const mapStateToProps = ({ show, publish: { file, thumbnail, fileError, isUpdate
 
 const mapDispatchToProps = dispatch => {
   return {
-    selectFile: (file) => {
+    selectFile: file => {
       dispatch(selectFile(file));
     },
-    setFileError: (value) => {
+    setFileError: value => {
       dispatch(clearFile());
       dispatch(updateError('file', value));
     },
   };
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(View);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(View);

--- a/client/src/utils/file.js
+++ b/client/src/utils/file.js
@@ -1,15 +1,12 @@
 import siteConfig from '@config/siteConfig.json';
 
 const {
-  publishing: {
-    maxSizeImage = 10000000,
-    maxSizeGif = 50000000,
-    maxSizeVideo = 50000000,
-  }
+  publishing: { maxSizeImage = 10000000, maxSizeGif = 50000000, maxSizeVideo = 50000000 },
 } = siteConfig;
+// TODO: central constants location
+const SIZE_MB = 1000000;
 
-
-export function validateFile (file) {
+export function validateFile(file) {
   if (!file) {
     throw new Error('no file provided');
   }
@@ -36,6 +33,9 @@ export function validateFile (file) {
       }
       break;
     default:
-      throw new Error(file.type + ' is not a supported file type. Only, .jpeg, .png, .gif, and .mp4 files are currently supported.');
+      throw new Error(
+        file.type +
+          ' is not a supported file type. Only, .jpeg, .png, .gif, and .mp4 files are currently supported.'
+      );
   }
 }

--- a/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
+++ b/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const validateFileTypeAndSize = require('./validateFileTypeAndSize.js');
 
-const parsePublishApiRequestFiles = ({file, thumbnail}, isUpdate) => {
+const parsePublishApiRequestFiles = ({ file, thumbnail }, isUpdate) => {
   // make sure a file was provided
   if (!file) {
     if (isUpdate) {
@@ -14,39 +14,39 @@ const parsePublishApiRequestFiles = ({file, thumbnail}, isUpdate) => {
       }
       return {};
     }
-    throw new Error('no file with key of [file] found in request');
+    throw new Error('No file with key of [file] found in request');
   }
   if (!file.path) {
-    throw new Error('no file path found');
+    throw new Error('No file path found');
   }
   if (!file.type) {
-    throw new Error('no file type found');
+    throw new Error('No file type found');
   }
   if (!file.size) {
-    throw new Error('no file size found');
+    throw new Error('No file size found');
   }
   // validate the file name
   if (!file.name) {
-    throw new Error('no file name found');
+    throw new Error('No file name found');
   }
   if (file.name.indexOf('.') < 0) {
-    throw new Error('no file extension found in file name');
+    throw new Error('No file extension found in file name');
   }
   if (file.name.indexOf('.') === 0) {
-    throw new Error('file name cannot start with "."');
+    throw new Error('File name cannot start with "."');
   }
   if (/'/.test(file.name)) {
-    throw new Error('apostrophes are not allowed in the file name');
+    throw new Error('Apostrophes are not allowed in the file name');
   }
 
   // validate the file
   if (file) validateFileTypeAndSize(file);
   // return results
   const obj = {
-    fileName     : file.name,
-    filePath     : file.path,
+    fileName: file.name,
+    filePath: file.path,
     fileExtension: path.extname(file.path),
-    fileType     : file.type,
+    fileType: file.type,
   };
 
   if (thumbnail) {


### PR DESCRIPTION
Fixes a bug where file errors weren't showing up. They're basic red text now, but they're there.
Test: Try to upload a file with an apostrophe in it. Try to upload a giant video, or one without an extension.