### PR TITLE
fixes bug in edit page due to inconsistent url

### DIFF
--- a/server/controllers/api/channel/claims/getChannelClaims.js
+++ b/server/controllers/api/channel/claims/getChannelClaims.js
@@ -3,30 +3,37 @@ const chainquery = require('chainquery').default;
 const getClaimData = require('server/utils/getClaimData');
 const { returnPaginatedChannelClaims } = require('./channelPagination.js');
 
-const getChannelClaims = async (channelName, channelShortId, page) => {
-  const channelId = await chainquery.claim.queries.getLongClaimId(channelName, channelShortId);
-  const params = { content_type: [
-    'image/jpeg',
-    'image/jpg',
-    'image/png',
-    'image/gif',
-    'video/mp4',
-  ] };
-  let channelClaims;
-  if (channelId) {
-    channelClaims = await chainquery.claim.queries.getAllChannelClaims(channelId, params);
-  }
+const getChannelClaims = async (channelName, channelLongId, page) => {
+  const params = {
+    content_type: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'video/mp4'],
+  };
 
+  let channelShortId = await chainquery.claim.queries.getShortClaimIdFromLongClaimId(
+    channelLongId,
+    channelName
+  );
+  let channelClaims;
+  if (channelLongId) {
+    channelClaims = await chainquery.claim.queries.getAllChannelClaims(channelLongId, params);
+  }
+  /*
+    Put mempool unconfirmed claims at the beginning
+   */
   const split = channelClaims.reduce(
-    (acc, val) => val.dataValues.height === 0 ? { ...acc, zero: acc.zero.concat(val) } : { ...acc, nonzero: acc.nonzero.concat(val) },
+    (acc, val) =>
+      val.dataValues.height === 0
+        ? { ...acc, zero: acc.zero.concat(val) }
+        : { ...acc, nonzero: acc.nonzero.concat(val) },
     { zero: [], nonzero: [] }
   );
   channelClaims = split.zero.concat(split.nonzero);
 
-  const processingChannelClaims = channelClaims ? channelClaims.map((claim) => getClaimData(claim, channelName, channelShortId)) : [];
+  const processingChannelClaims = channelClaims
+    ? channelClaims.map(claim => getClaimData(claim, channelName, channelShortId))
+    : [];
   const processedChannelClaims = await Promise.all(processingChannelClaims);
 
-  return returnPaginatedChannelClaims(channelName, channelId, processedChannelClaims, page);
+  return returnPaginatedChannelClaims(channelName, channelShortId, processedChannelClaims, page);
 };
 
 module.exports = getChannelClaims;


### PR DESCRIPTION
A function for populating the channel list details was expecting a shortId was being passed a longId. It was simpler to change it to accept a longId. 