### PR TITLE
Refactor publish and validation and servability for all file types

### DIFF
--- a/cli/defaults/siteConfig.json
+++ b/cli/defaults/siteConfig.json
@@ -60,7 +60,19 @@
       "publicDisallowedTypesMain": []
     },
     "customFileExtensions": {
-      "application/example-type": "example"
+      "application/x-troff-man": ".man",
+      "application/x-troff-me": ".me",
+      "application/x-mif": ".mif",
+      "application/x-troff-ms": ".ms",
+      "application/x-troff": ".roff",
+      "application/x-python-code": ".pyc",
+      "text/x-python": ".py",
+      "application/x-pn-realaudio": ".ram",
+      "application/x-sgml": ".sgm",
+      "model/stl": ".stl",
+      "image/pict": ".pct",
+      "text/xul": ".xul",
+      "text/x-go": "go"
     }
   },
   "startup": {

--- a/cli/defaults/siteConfig.json
+++ b/cli/defaults/siteConfig.json
@@ -23,7 +23,7 @@
   "publishing": {
     "primaryClaimAddress": null,
     "uploadDirectory": "/home/lbry/Uploads",
-    "lbrynetHome": "/home/lbry",
+    "lbrynetHome": "/CURRENTLYUNUSED",
     "thumbnailChannel": null,
     "thumbnailChannelId": null,
     "additionalClaimAddresses": [],
@@ -36,6 +36,17 @@
     "publishingChannelWhitelist": [],
     "channelClaimBidAmount": "0.1",
     "fileClaimBidAmount": "0.01",
+    "fileSizeLimits": {
+      "image": 50000000,
+      "video": 50000000,
+      "audio": 50000000,
+      "text": 50000000,
+      "model": 50000000,
+      "application": 50000000,
+      "customByContentType": {
+        "application/octet-stream": 50000000
+      }
+    },
     "maxSizeImage": 10000000,
     "maxSizeGif": 50000000,
     "maxSizeVideo": 50000000

--- a/client/src/components/DropzonePreviewImage/index.jsx
+++ b/client/src/components/DropzonePreviewImage/index.jsx
@@ -5,8 +5,9 @@ class PublishPreview extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
-      imgSource       : '',
-      defaultThumbnail: '/assets/img/video_thumb_default.png',
+      imgSource            : '',
+      defaultVideoThumbnail: '/assets/img/video_thumb_default.png',
+      defaultThumbnail     : '/assets/img/Speech_Logo_Main@OG-02.jpg',
     };
   }
   componentDidMount () {
@@ -37,12 +38,13 @@ class PublishPreview extends React.Component {
     };
   }
   setPreviewImageSource (file) {
-    if (file.type !== 'video/mp4') {
+    if (this.props.thumbnail) {
+      this.setPreviewImageSourceFromFile(this.props.thumbnail);
+    } else if (file.type.substr(0, file.type.indexOf('/')) === 'image'){
       this.setPreviewImageSourceFromFile(file);
+    } else if (file.type === 'video'){
+      this.setState({imgSource: this.state.defaultVideoThumbnail});
     } else {
-      if (this.props.thumbnail) {
-        this.setPreviewImageSourceFromFile(this.props.thumbnail);
-      }
       this.setState({imgSource: this.state.defaultThumbnail});
     }
   }

--- a/client/src/containers/Dropzone/view.jsx
+++ b/client/src/containers/Dropzone/view.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { validateFile } from '../../utils/file';
 import Memeify from '@components/Memeify';
 import DropzonePreviewImage from '@components/DropzonePreviewImage';
 import DropzoneDropItDisplay from '@components/DropzoneDropItDisplay';
 import DropzoneInstructionsDisplay from '@components/DropzoneInstructionsDisplay';
+import validateFileForPublish from '@globalutils/validateFileForPublish';
 
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
 
 const isFacebook = (() => {
@@ -29,7 +29,7 @@ class Dropzone extends React.Component {
       memeify    : false,
     };
 
-    if(props.file) {
+    if (props.file) {
       // No side effects allowed with `getDerivedStateFromProps`, so
       // we must use `componentDidUpdate` and `constructor` routines.
       // Note: `FileReader` has an `onloadend` side-effect
@@ -133,7 +133,7 @@ class Dropzone extends React.Component {
   chooseFile (file) {
     if (file) {
       try {
-        validateFile(file); // validate the file's name, type, and size
+        validateFileForPublish(file); // validate the file's name, type, and size
       } catch (error) {
         return this.props.setFileError(error.message);
       }

--- a/client/src/utils/createAssetMetaTags.js
+++ b/client/src/utils/createAssetMetaTags.js
@@ -47,8 +47,6 @@ const createAssetMetaTags = asset => {
   const ogThumbnailContentType = determineContentTypeFromExtension(claimData.thumbnail);
   const ogThumbnail = claimData.thumbnail || defaultThumbnail;
 
-  console.log('asset.claimData', asset.claimData);
-
   // {property: 'og:title'] = ogTitle},
   const metaTags = {
     'og:title': ogTitle,

--- a/server/chainquery/models/ClaimModel.js
+++ b/server/chainquery/models/ClaimModel.js
@@ -1,9 +1,17 @@
 const logger = require('winston');
 const mime = require('mime-types');
+const {
+  serving: { customFileExtensions },
+} = require('@config/siteConfig');
 
 const getterMethods = {
   generated_extension() {
-    return mime.extension(this.content_type) ? mime.extension(this.content_type) : 'jpg';
+    logger.info('trying to generate extension', this.content_type);
+    if (customFileExtensions.hasOwnProperty(this.content_type)) {
+      return customFileExtensions[this.content_type];
+    } else {
+      return mime.extension(this.content_type) ? mime.extension(this.content_type) : 'jpg';
+    }
   },
 };
 

--- a/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
+++ b/server/controllers/api/claim/publish/parsePublishApiRequestFiles.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const validateFileTypeAndSize = require('./validateFileTypeAndSize.js');
+const validateFileForPublish = require('./validateFileForPublish.js');
 
 const parsePublishApiRequestFiles = ({ file, thumbnail }, isUpdate) => {
   // make sure a file was provided
@@ -40,7 +41,7 @@ const parsePublishApiRequestFiles = ({ file, thumbnail }, isUpdate) => {
   }
 
   // validate the file
-  if (file) validateFileTypeAndSize(file);
+  if (file) validateFileForPublish(file);
   // return results
   const obj = {
     fileName: file.name,

--- a/server/controllers/api/claim/publish/validateFileForPublish.js
+++ b/server/controllers/api/claim/publish/validateFileForPublish.js
@@ -1,10 +1,12 @@
-import { publishing } from '@config/siteConfig.json';
+const logger = require('winston');
+
+const { publishing } = require('@config/siteConfig.json');
 
 const { fileSizeLimits } = publishing;
 
 const SIZE_MB = 1000000;
 
-export default function validateFileForPublish(file) {
+const validateFileForPublish = file => {
   let contentType = file.type;
   let mediaType = contentType ? contentType.substr(0, contentType.indexOf('/')) : '';
   let mediaTypeLimit = fileSizeLimits[mediaType] || false;
@@ -31,4 +33,6 @@ export default function validateFileForPublish(file) {
     }
   }
   return file;
-}
+};
+
+module.exports = validateFileForPublish;

--- a/utils/validateFileForPublish.js
+++ b/utils/validateFileForPublish.js
@@ -1,0 +1,75 @@
+import { publishing } from '@config/siteConfig.json';
+
+const {
+  fileSizeLimits: {
+    image: maxSizeImage = 10000000,
+    video: maxSizeVideo = 50000000,
+    audio: maxSizeAudio = 50000000,
+    text: maxSizeText = 50000000,
+    model: maxSizeModel = 50000000,
+    application: maxSizeApplication = 50000000,
+    customByContentType,
+  },
+} = publishing;
+
+const SIZE_MB = 1000000;
+
+export const validateFileForPublish = file => {
+  let contentType = file.type;
+  let mediaType = contentType ? contentType.substr(0, contentType.indexOf('/')) : '';
+
+  if (!file) {
+    throw new Error('no file provided');
+  }
+
+  if (/'/.test(file.name)) {
+    throw new Error('apostrophes are not allowed in the file name');
+  }
+
+  if (Object.keys(customByContentType).includes(contentType)) {
+    if (file.size > customByContentType[contentType]) {
+      throw new Error(
+        `Sorry, type ${contentType} is limited to ${customByContentType[contentType] / SIZE_MB} MB.`
+      );
+    }
+  } else {
+    switch (mediaType) {
+      case 'image':
+        if (file.size > maxSizeImage) {
+          throw new Error(`Sorry, type ${mediaType} is limited to ${maxSizeImage / SIZE_MB} MB.`);
+        }
+        break;
+      case 'audio':
+        if (file.size > maxSizeAudio) {
+          throw new Error(`Sorry, type ${mediaType} is limited to ${maxSizeAudio / SIZE_MB} MB.`);
+        }
+        break;
+      case 'video':
+        if (file.size > maxSizeVideo) {
+          throw new Error(`Sorry, type ${mediaType} is limited to ${maxSizeVideo / SIZE_MB} MB.`);
+        }
+        break;
+      case 'text':
+        if (file.size > maxSizeText) {
+          throw new Error(`Sorry, type ${mediaType} is limited to ${maxSizeText / SIZE_MB} MB.`);
+        }
+        break;
+      case 'model':
+        if (file.size > maxSizeModel) {
+          throw new Error(`Sorry, type ${mediaType} is limited to ${maxSizeModel / SIZE_MB} MB.`);
+        }
+        break;
+      case 'application':
+        if (file.size > maxSizeApplication) {
+          throw new Error(
+            `Sorry, type ${mediaType} is limited to ${maxSizeApplication / SIZE_MB} MB.`
+          );
+        }
+        break;
+      default:
+        throw new Error(`Missing or unrecognized file type`);
+    }
+    return false;
+  }
+  return file;
+};


### PR DESCRIPTION

This one will probably have breaking changes when deployed unless:
 - site/custom/scss _variables is manually updated, and 
 - cli/defaults/siteConfig is manually updated to /site/config/siteConfig 

Improvements made:
 - more granular file size limit settings
 - no more hardcoded type restrictions
 - chainquery correctly assigns extensions in an extensible way

Todo: conditionally don't try to find file dimensions.