### PR TITLE
updates for sdk .32

### DIFF
--- a/server/controllers/api/claim/update/index.js
+++ b/server/controllers/api/claim/update/index.js
@@ -1,6 +1,9 @@
 const logger = require('winston');
 const db = require('server/models');
-const { details, publishing: { disabled, disabledMessage, primaryClaimAddress } } = require('@config/siteConfig');
+const {
+  details,
+  publishing: { disabled, disabledMessage, primaryClaimAddress },
+} = require('@config/siteConfig');
 const { resolveUri } = require('server/lbrynet');
 const { sendGATimingEvent } = require('../../../../utils/googleAnalytics.js');
 const { handleErrorResponse } = require('../../../utils/errorHandlers.js');
@@ -16,7 +19,7 @@ const createCanonicalLink = require('@globalutils/createCanonicalLink');
   route to update a claim through the daemon
 */
 
-const updateMetadata = ({nsfw, license, title, description}) => {
+const updateMetadata = ({ nsfw, license, title, description }) => {
   const update = {};
   if (nsfw) update['nsfw'] = nsfw;
   if (license) update['license'] = license;
@@ -76,11 +79,19 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
   gaStartTime = Date.now();
 
   try {
-    ({name, nsfw, license, title, description, thumbnail} = parsePublishApiRequestBody(body));
-    ({fileName, filePath, fileExtension, fileType, thumbnailFileName, thumbnailFilePath, thumbnailFileType} = parsePublishApiRequestFiles(files, true));
-    ({channelName, channelId, channelPassword} = body);
+    ({ name, nsfw, license, title, description, thumbnail } = parsePublishApiRequestBody(body));
+    ({
+      fileName,
+      filePath,
+      fileExtension,
+      fileType,
+      thumbnailFileName,
+      thumbnailFilePath,
+      thumbnailFileType,
+    } = parsePublishApiRequestFiles(files, true));
+    ({ channelName, channelId, channelPassword } = body);
   } catch (error) {
-    return res.status(400).json({success: false, message: error.message});
+    return res.status(400).json({ success: false, message: error.message });
   }
 
   // check channel authorization
@@ -89,7 +100,9 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
       if (!channelId) {
         channelId = channelClaimId;
       }
-      return chainquery.claim.queries.resolveClaimInChannel(name, channelClaimId).then(claim => claim.dataValues);
+      return chainquery.claim.queries
+        .resolveClaimInChannel(name, channelClaimId)
+        .then(claim => claim.dataValues);
     })
     .then(claim => {
       claimRecord = claim;
@@ -107,20 +120,24 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
       return [null, null];
     })
     .then(([fileResult, resolution]) => {
-      metadata = Object.assign({}, {
-        title      : claimRecord.title,
-        description: claimRecord.description,
-        nsfw       : claimRecord.nsfw,
-        license    : claimRecord.license,
-        language   : 'en',
-        author     : details.title,
-      }, updateMetadata({title, description, nsfw, license}));
+      metadata = Object.assign(
+        {},
+        {
+          title: claimRecord.title,
+          description: claimRecord.description,
+          nsfw: claimRecord.nsfw,
+          license: claimRecord.license,
+          language: 'en',
+          author: details.title,
+        },
+        updateMetadata({ title, description, nsfw, license })
+      );
       const publishParams = {
         name,
-        bid          : '0.01',
+        bid: '0.01',
         claim_address: primaryClaimAddress,
-        channel_name : channelName,
-        channel_id   : channelId,
+        channel_name: channelName,
+        channel_id: channelId,
         metadata,
       };
 
@@ -128,19 +145,24 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
         if (thumbnailUpdate) {
           // publish new thumbnail
           const newThumbnailName = `${name}-${rando()}`;
-          const newThumbnailParams = createThumbnailPublishParams(filePath, newThumbnailName, license, nsfw);
+          const newThumbnailParams = createThumbnailPublishParams(
+            filePath,
+            newThumbnailName,
+            license,
+            nsfw
+          );
           newThumbnailParams['file_path'] = filePath;
           publish(newThumbnailParams, fileName, fileType);
 
-          publishParams['sources'] = resolution.claim.value.stream.source;
-          publishParams['thumbnail'] = `${details.host}/${newThumbnailParams.channel_name}:${newThumbnailParams.channel_id}/${newThumbnailName}-thumb.jpg`;
+          publishParams['thumbnail'] = `${details.host}/${newThumbnailParams.channel_name}:${
+            newThumbnailParams.channel_id
+          }/${newThumbnailName}-thumb.jpg`;
         } else {
           publishParams['file_path'] = filePath;
         }
       } else {
         fileName = fileResult.fileName;
         fileType = fileResult.fileType;
-        publishParams['sources'] = resolution.claim.value.stream.source;
         publishParams['thumbnail'] = claimRecord.thumbnail_url;
       }
 
@@ -151,17 +173,24 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
       publishResult = result;
 
       if (channelName) {
-        return chainquery.claim.queries.getShortClaimIdFromLongClaimId(result.certificateId, channelName);
+        return chainquery.claim.queries.getShortClaimIdFromLongClaimId(
+          result.certificateId,
+          channelName
+        );
       } else {
-        return chainquery.claim.queries.getShortClaimIdFromLongClaimId(result.claimId, name, result).catch(() => {
-          return result.claimId.slice(0, 1);
-        });
+        return chainquery.claim.queries
+          .getShortClaimIdFromLongClaimId(result.claimId, name, result)
+          .catch(() => {
+            return result.claimId.slice(0, 1);
+          });
       }
     })
     .then(shortId => {
       let canonicalUrl;
       if (channelName) {
-        canonicalUrl = createCanonicalLink({ asset: { ...publishResult, channelShortId: shortId } });
+        canonicalUrl = createCanonicalLink({
+          asset: { ...publishResult, channelShortId: shortId },
+        });
       } else {
         canonicalUrl = createCanonicalLink({ asset: { ...publishResult, shortId } });
       }
@@ -173,17 +202,17 @@ const claimUpdate = ({ body, files, headers, ip, originalUrl, user, tor }, res) 
         });
       }
 
-      const {claimId} = publishResult;
+      const { claimId } = publishResult;
       res.status(200).json({
         success: true,
         message: 'update successful',
-        data   : {
+        data: {
           name,
           claimId,
-          url      : `${details.host}${canonicalUrl}`, // for backwards compatability with app
-          showUrl  : `${details.host}${canonicalUrl}`,
-          serveUrl : `${details.host}${canonicalUrl}${fileExtension}`,
-          pushTo   : canonicalUrl,
+          url: `${details.host}${canonicalUrl}`, // for backwards compatability with app
+          showUrl: `${details.host}${canonicalUrl}`,
+          serveUrl: `${details.host}${canonicalUrl}${fileExtension}`,
+          pushTo: canonicalUrl,
           claimData: publishResult,
         },
       });

--- a/server/lbrynet/index.js
+++ b/server/lbrynet/index.js
@@ -93,7 +93,7 @@ module.exports = {
       axios
         .post(lbrynetUri, {
           method: 'resolve',
-          params: { uri },
+          params: { urls: uri },
         })
         .then(({ data }) => {
           sendGATimingEvent('lbrynet', 'resolveUri', 'RESOLVE', gaStartTime, Date.now());


### PR DESCRIPTION
resolveUri presents `urls:` as a parameter instead of `uri:`
extraneous unsupported `sources:` field removed from publishParams[]