### PR TITLE
Updated the download link to retain file extension.

### DIFF
--- a/client/src/containers/AssetInfo/view.jsx
+++ b/client/src/containers/AssetInfo/view.jsx
@@ -140,7 +140,7 @@ class AssetInfo extends React.Component {
           <a
             className={'link--primary'}
             href={`${assetCanonicalUrl}.${fileExt}`}
-            download={name}
+            download={`${name}.${fileExt}`}
           >
             Download
           </a>


### PR DESCRIPTION
Updated the download URL to retain the file extension. Before, when you would download the file it would not append the file extension, this will fix that.