### PR TITLE
uses CQ-derived outpoint and file list to detect foreign file changes

### DIFF
--- a/server/controllers/api/file/availability/index.js
+++ b/server/controllers/api/file/availability/index.js
@@ -1,5 +1,9 @@
+const logger = require('winston');
+
 const { handleErrorResponse } = require('../../../utils/errorHandlers.js');
-const db = require('../../../../models');
+const { getFileListFileByOutpoint } = require('server/lbrynet');
+
+const chainquery = require('chainquery').default;
 
 /*
 
@@ -10,18 +14,24 @@ const db = require('../../../../models');
 const fileAvailability = ({ ip, originalUrl, params }, res) => {
   const name = params.name;
   const claimId = params.claimId;
-  db.File
-    .findOne({
-      where: {
-        name,
-        claimId,
-      },
+  logger.debug(`fileAvailability params: name:${name} claimId:${claimId}`);
+  // TODO: we probably eventually want to check the publishCache for the claimId too,
+  //  and shop the outpoint to file_list.
+  return chainquery.claim.queries
+    .resolveClaim(name, claimId)
+    .then(result => {
+      return `${result.dataValues.transaction_hash_id}:${result.dataValues.vout}`;
+    })
+    .then(outpoint => {
+      logger.debug(`fileAvailability: outpoint: ${outpoint}`);
+      return getFileListFileByOutpoint(outpoint);
     })
     .then(result => {
-      if (result) {
-        return res.status(200).json({success: true, data: true});
+      if (result && result[0]) {
+        return res.status(200).json({ success: true, data: true });
+      } else {
+        res.status(200).json({ success: true, data: false });
       }
-      res.status(200).json({success: true, data: false});
     })
     .catch(error => {
       handleErrorResponse(originalUrl, ip, error, res);


### PR DESCRIPTION
Before, one instance of speech, already having a file entry in its database, would not check if another instance had updated the file. 

Now it does. We no longer use fileDB for availability in this case.