### PR TITLE
Added Server Response Error Handling

### DIFF
--- a/client/src/channels/publish.js
+++ b/client/src/channels/publish.js
@@ -22,16 +22,16 @@ export const makePublishRequestChannel = (fd, isUpdate) => {
     xhr.upload.addEventListener('load', onLoad);
     // set state change handler
     xhr.onreadystatechange = () => {
-      if (xhr.readyState === 4) {
-	      switch (xhr.status) {
-	        case 413:
-	          emitter({error: new Error("Unfortunately it appears this web server " +
-	            "has been misconfigured, please inform the service administrators " +
-	            "that they must set their nginx/apache request size maximums higher " +
-	            "than their file size limits.")});
-	          emitter(END);
-	          break;
-	        case 200:
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        switch (xhr.status) {
+          case 413:
+            emitter({error: new Error("Unfortunately it appears this web server " +
+              "has been misconfigured, please inform the service administrators " +
+              "that they must set their nginx/apache request size maximums higher " +
+              "than their file size limits.")});
+            emitter(END);
+            break;
+          case 200:
             var response = JSON.parse(xhr.response);
             if (response.success) {
               emitter({success: response});
@@ -40,12 +40,12 @@ export const makePublishRequestChannel = (fd, isUpdate) => {
               emitter({error: new Error(response.message)});
               emitter(END);
             }
-	          break;
-	        default:
-	          emitter({error: new Error("Received an unexpected response from " +
+            break;
+          default:
+            emitter({error: new Error("Received an unexpected response from " +
               "server: " + xhr.status)});
-	          emitter(END);
-	      }
+            emitter(END);
+        }
       }
     };
     // open and send


### PR DESCRIPTION
Presently the spee.ch client will error out if it received an unexpected response, resulting in hangs and a very vague JSON parsing error. This failsafe will catch the known issue of server request size limits causing 413 responses if misconfigured, making things easier to diagnose, as well as catching any other unexpected responses cleanly. Further specific behaviours can be added to ensure administrators spend less time debugging simple configuration issues.

The 413 error response should be fairly self explanatory, sufficient to not need further documentation, though adding an addendum to the README.md would aid other developers have a smooth experience.